### PR TITLE
Feat #24 [EntityControlPanel] 3D 모델 레이어 조작 1차 구현

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		272BD1B32EADE1BF00C83F81 /* ARSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272BD1B12EADE1BA00C83F81 /* ARSessionController.swift */; };
 		272BD1B52EADE1E200C83F81 /* HeadPose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272BD1B42EADE1DE00C83F81 /* HeadPose.swift */; };
 		272BD1B62EADE1E200C83F81 /* HeadPose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272BD1B42EADE1DE00C83F81 /* HeadPose.swift */; };
+		27D8A2BE2EAF682B009429F0 /* OpacityControlViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D8A2BD2EAF67CE009429F0 /* OpacityControlViewModel.swift */; };
 		C02FFA752E9FFF6F00F16742 /* HippoVisionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02FFA4F2E9FFF6F00F16742 /* HippoVisionApp.swift */; };
 		C02FFA762E9FFF6F00F16742 /* HippoMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02FFA4C2E9FFF6F00F16742 /* HippoMacApp.swift */; };
 		C02FFA792E9FFF6F00F16742 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02FFA6A2E9FFF6F00F16742 /* AppModel.swift */; };
@@ -299,6 +300,7 @@
 		14F6B0332EAAC73F003F28EB /* ImmersiveSurgeryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersiveSurgeryView.swift; sourceTree = "<group>"; };
 		272BD1B12EADE1BA00C83F81 /* ARSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARSessionController.swift; sourceTree = "<group>"; };
 		272BD1B42EADE1DE00C83F81 /* HeadPose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadPose.swift; sourceTree = "<group>"; };
+		27D8A2BD2EAF67CE009429F0 /* OpacityControlViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpacityControlViewModel.swift; sourceTree = "<group>"; };
 		C02FFA4C2E9FFF6F00F16742 /* HippoMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HippoMacApp.swift; sourceTree = "<group>"; };
 		C02FFA4D2E9FFF6F00F16742 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C02FFA4F2E9FFF6F00F16742 /* HippoVisionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HippoVisionApp.swift; sourceTree = "<group>"; };
@@ -848,6 +850,7 @@
 		C050AA242EA8150500352314 /* Immersive */ = {
 			isa = PBXGroup;
 			children = (
+				27D8A2BD2EAF67CE009429F0 /* OpacityControlViewModel.swift */,
 				1446FB9B2EAE6987000BCF61 /* Components */,
 				14F6B0332EAAC73F003F28EB /* ImmersiveSurgeryView.swift */,
 			);
@@ -1163,6 +1166,7 @@
 				C0F97ACD2EA41D4B0063E159 /* SDOperationRecording.swift in Sources */,
 				14CC75562EA6A8BE00399562 /* LogoHeader.swift in Sources */,
 				C0F97ACE2EA41D4B0063E159 /* SwiftDataMappers.swift in Sources */,
+				27D8A2BE2EAF682B009429F0 /* OpacityControlViewModel.swift in Sources */,
 				C0F97ACF2EA41D4B0063E159 /* PatientLocalDataSourceSwiftData.swift in Sources */,
 				C050AA3C2EA8197E00352314 /* ImmersiveIDs.swift in Sources */,
 				C0F97AD02EA41D4B0063E159 /* SDOperationAsset.swift in Sources */,

--- a/Hippo/Features/Vision/Runtime/ARSessionController.swift
+++ b/Hippo/Features/Vision/Runtime/ARSessionController.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import ARKit
 
 @MainActor
-@Observable
 final class ARSessionController {
     static let shared = ARSessionController()
     

--- a/Hippo/Features/Vision/Runtime/HeadPose.swift
+++ b/Hippo/Features/Vision/Runtime/HeadPose.swift
@@ -10,7 +10,6 @@ import RealityKit
 import ARKit
 
 @MainActor
-@Observable
 class HeadPose {
     
     // Singleton

--- a/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
+++ b/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
@@ -1,0 +1,78 @@
+//
+//  OpacityControlViewModel.swift
+//  Hippo
+//
+//  Created by yunsly on 10/27/25.
+//
+
+import RealityKit
+import SwiftUI
+import Combine
+
+@Observable
+final class OpacityControlViewModel {
+    
+    struct Layer: Identifiable {
+        let id: UUID
+        let name: String
+        let entity: Entity
+        var isVisible: Bool
+        var opacity: Float
+    }
+    
+    var layers: [Layer] = []
+    private var runtime: ImmersiveSceneRuntime
+    
+    init(runtime: ImmersiveSceneRuntime) {
+        self.runtime = runtime
+    }
+    
+    // MARK: -- Layer 탐색
+    
+    // Panel 에서 호출: selectedEntity 가 변경될 때마다 갱신
+    func reloadLayers() {
+        guard let entity = runtime.selectedEntity else {
+            layers = []
+            return
+        }
+        
+        let leafNodes = collectLeafNodes(from: entity)
+        layers = leafNodes.enumerated().map { idx, e in
+            Layer(id: UUID(),
+                  name: e.name.isEmpty ? "Layer \(idx + 1)" : e.name,
+                  entity: e,
+                  isVisible: e.isEnabled,
+                  opacity: 1.0)
+        }
+    }
+    
+    private func collectLeafNodes(from entity: Entity) -> [Entity] {
+        if entity.children.isEmpty {
+            return (entity.components[ModelComponent.self] != nil) ? [entity] : []
+        }
+        return entity.children.flatMap { collectLeafNodes(from: $0) }
+    }
+    
+    // MARK: -- 선택된 Layer 들의 visibility / Opacity 조정
+    
+    // 선택된 layer 의 visibility 설정
+    func toggleVisibility(for partID: Layer.ID) {
+        guard let index = layers.firstIndex(where: { $0.id == partID }) else { return }
+        
+        let newVisibility = !layers[index].isVisible
+        layers[index].isVisible = newVisibility
+        layers[index].entity.isEnabled = newVisibility
+    }
+    
+    
+    // 선택된 layer들의 Opacity 조정
+    func setOpacity(for partIDs: [Layer.ID], opacity: Float) {
+        for partID in partIDs {
+            guard let index = layers.firstIndex(where: { $0.id == partID }) else { return }
+            
+            layers[index].opacity = opacity
+            let opacityComponent = OpacityComponent(opacity: opacity)
+            layers[index].entity.components.set(opacityComponent)
+        }
+    }
+}

--- a/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
+++ b/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
@@ -13,7 +13,7 @@ import Combine
 final class OpacityControlViewModel {
     
     struct Layer: Identifiable {
-        let id: UUID
+        let id: String
         let name: String
         let entity: Entity
         var isVisible: Bool
@@ -38,11 +38,13 @@ final class OpacityControlViewModel {
         
         let leafNodes = collectLeafNodes(from: entity)
         layers = leafNodes.enumerated().map { idx, e in
-            Layer(id: UUID(),
+            let currentOpacity = e.components[OpacityComponent.self]?.opacity ?? 1.0
+            
+            return Layer(id: Self.layerID(for: e),
                   name: e.name.isEmpty ? "Layer \(idx + 1)" : e.name,
                   entity: e,
                   isVisible: e.isEnabled,
-                  opacity: 1.0)
+                  opacity: currentOpacity)
         }
     }
     
@@ -52,6 +54,18 @@ final class OpacityControlViewModel {
         }
         return entity.children.flatMap { collectLeafNodes(from: $0) }
     }
+    
+    private static func layerID(for entity: Entity) -> String {
+        var chain: [String] = []
+        var current: Entity? = entity
+        while let e = current {
+            chain.append(e.name)
+            current = e.parent
+        }
+        let path = chain.reversed().joined(separator: "/")
+        return String(path.hashValue)
+    }
+    
     
     // MARK: -- 선택된 Layer 들의 visibility / Opacity 조정
     
@@ -68,7 +82,7 @@ final class OpacityControlViewModel {
     // 선택된 layer들의 Opacity 조정
     func setOpacity(for partIDs: [Layer.ID], opacity: Float) {
         for partID in partIDs {
-            guard let index = layers.firstIndex(where: { $0.id == partID }) else { return }
+            guard let index = layers.firstIndex(where: { $0.id == partID }) else { continue }
             
             layers[index].opacity = opacity
             let opacityComponent = OpacityComponent(opacity: opacity)


### PR DESCRIPTION
## 📕 Issue Number

#24 

UI 단과 연결 후 close 하겠습니다.

## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

**1. OpacityControlViewModel 생성**
    - reloadLayers() : runtime 의 selectedEntity 의 트리를 순회하며 리프 노드 수집하여 Layers 구조체에 저장
    - toggleVisibility(for partID: Layer.ID) : 선택한 레이어의 uuid 를 넘기면 레이어의 on / off
    - setOpacity(for partIDs: [Layer.ID], opacity: Float) : 선택한 레이어들의 uuid 리스트와 opacity 를 넘기면 레이어의 opacity 조정

**2. 빌드 확인 완.**


## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

이후 OpacityControlPanel 뷰 연결할 때,
1. 주입된 runtime 의 selectedEntity 변경 시 reloadLayers() 함수 호출
2. 레이어 조작값은 Binding() 의 get / set 으로 연결하면 되지 않을까 생각합니다. 
3. OpacityControlViewModel 을 OpacityControlPanel 이 들고 있는 것이 나은지, 아니면 ImmersiveSurgeryView 에서 환경객체로 주입해 OpacityControlPanel 에서 @EnvironmentObject 로 받아서 사용하는 것이 나은지 궁금합니다! 큰 차이가 있을까 싶긴 한데 어떻게 연결해야 할 지 고민 고민 중.

<br><br>
