### PR TITLE
Feat/#4 patient detail view hifi

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		1446FBD52EAF262F000BCF61 /* EntityPlacementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1446FBD22EAF262F000BCF61 /* EntityPlacementService.swift */; };
 		1446FBDE2EAF2962000BCF61 /* HippoAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1446FBDD2EAF2962000BCF61 /* HippoAlertView.swift */; };
 		1446FBE42EAF5801000BCF61 /* PatientInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1446FBE22EAF5801000BCF61 /* PatientInputView.swift */; };
+		1446FBE82EAF9E3B000BCF61 /* PatientDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1446FBE72EAF9E3B000BCF61 /* PatientDetailView.swift */; };
+		1446FBEA2EAFA132000BCF61 /* PatientViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1446FBE92EAFA129000BCF61 /* PatientViewModel.swift */; };
 		146F102D2EA3AD1500DDDC35 /* HippoAssets in Frameworks */ = {isa = PBXBuildFile; productRef = 146F102C2EA3AD1500DDDC35 /* HippoAssets */; };
 		146F10302EA3AF1000DDDC35 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F102E2EA3AF1000DDDC35 /* HomeView.swift */; };
 		146F10312EA3AF2D00DDDC35 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F102E2EA3AF1000DDDC35 /* HomeView.swift */; };
@@ -274,6 +276,8 @@
 		1446FBD22EAF262F000BCF61 /* EntityPlacementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityPlacementService.swift; sourceTree = "<group>"; };
 		1446FBDD2EAF2962000BCF61 /* HippoAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HippoAlertView.swift; sourceTree = "<group>"; };
 		1446FBE22EAF5801000BCF61 /* PatientInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientInputView.swift; sourceTree = "<group>"; };
+		1446FBE72EAF9E3B000BCF61 /* PatientDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientDetailView.swift; sourceTree = "<group>"; };
+		1446FBE92EAFA129000BCF61 /* PatientViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientViewModel.swift; sourceTree = "<group>"; };
 		145E0F4D2E9C0F3900CE6C97 /* HippoVision.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HippoVision.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		145E0F612E9C0F3B00CE6C97 /* HippoVisionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HippoVisionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		146F102A2EA3ACFD00DDDC35 /* HippoAssets */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HippoAssets; sourceTree = "<group>"; };
@@ -473,6 +477,8 @@
 			children = (
 				1446FBE12EAF5801000BCF61 /* Components */,
 				1446FBE22EAF5801000BCF61 /* PatientInputView.swift */,
+				1446FBE72EAF9E3B000BCF61 /* PatientDetailView.swift */,
+				1446FBE92EAFA129000BCF61 /* PatientViewModel.swift */,
 			);
 			path = Patient;
 			sourceTree = "<group>";
@@ -1206,6 +1212,7 @@
 				14CC75482EA69DE400399562 /* PatientCell.swift in Sources */,
 				C0F97B082EA430880063E159 /* Gender.swift in Sources */,
 				C0F97B092EA430880063E159 /* OperationAssetExtension.swift in Sources */,
+				1446FBEA2EAFA132000BCF61 /* PatientViewModel.swift in Sources */,
 				C0F97B262EA437840063E159 /* AttachAssetCommand.swift in Sources */,
 				C0F97B0A2EA430880063E159 /* OperationStatus.swift in Sources */,
 				1494DEA72EA7C851000CD284 /* Date+Extension.swift in Sources */,
@@ -1215,6 +1222,7 @@
 				C0F97ADA2EA420E10063E159 /* DataDependencies.swift in Sources */,
 				C0F97A8E2EA3FDF50063E159 /* DeleteOperation.swift in Sources */,
 				C0F97A8F2EA3FDF50063E159 /* RemoveAssetFromOperation.swift in Sources */,
+				1446FBE82EAF9E3B000BCF61 /* PatientDetailView.swift in Sources */,
 				C0F97A902EA3FDF50063E159 /* UpsertOperation.swift in Sources */,
 				C0F97A912EA3FDF50063E159 /* AttachAssetToOperation.swift in Sources */,
 				C04678402EA00B4A00D160DA /* HomeViewModel.swift in Sources */,

--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		146F102D2EA3AD1500DDDC35 /* HippoAssets in Frameworks */ = {isa = PBXBuildFile; productRef = 146F102C2EA3AD1500DDDC35 /* HippoAssets */; };
 		146F10302EA3AF1000DDDC35 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F102E2EA3AF1000DDDC35 /* HomeView.swift */; };
 		146F10312EA3AF2D00DDDC35 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F102E2EA3AF1000DDDC35 /* HomeView.swift */; };
+		147EB27D2EB0782100D9CFB3 /* OperationStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147EB27C2EB0781300D9CFB3 /* OperationStatusBadge.swift */; };
 		1494DE712EA72BCE000CD284 /* OperationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE702EA72BCE000CD284 /* OperationDetailView.swift */; };
 		1494DE722EA72BCE000CD284 /* OperationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE702EA72BCE000CD284 /* OperationDetailView.swift */; };
 		1494DE732EA72BCE000CD284 /* OperationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE702EA72BCE000CD284 /* OperationDetailView.swift */; };
@@ -80,6 +81,12 @@
 		1494DEA52EA7C851000CD284 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DEA42EA7C851000CD284 /* Date+Extension.swift */; };
 		1494DEA62EA7C851000CD284 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DEA42EA7C851000CD284 /* Date+Extension.swift */; };
 		1494DEA72EA7C851000CD284 /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DEA42EA7C851000CD284 /* Date+Extension.swift */; };
+		14A17F872EB31397009D16CF /* PatientDetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A17F862EB3138D009D16CF /* PatientDetailHeader.swift */; };
+		14A17F892EB313EA009D16CF /* OperationInfoSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A17F882EB313E6009D16CF /* OperationInfoSection.swift */; };
+		14A17F8B2EB31411009D16CF /* SurgeonInfoSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A17F8A2EB3140B009D16CF /* SurgeonInfoSection.swift */; };
+		14A17F8D2EB3146D009D16CF /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A17F8C2EB3146B009D16CF /* OperationCard.swift */; };
+		14A17F8F2EB31482009D16CF /* OperationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A17F8E2EB31480009D16CF /* OperationList.swift */; };
+		14A17F912EB314B3009D16CF /* EmptyOperationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A17F902EB314AF009D16CF /* EmptyOperationView.swift */; };
 		14C8FF6D2EABA4250089101B /* AttachmentIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8FF6C2EABA4200089101B /* AttachmentIDs.swift */; };
 		14C8FF6E2EABA4250089101B /* AttachmentIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8FF6C2EABA4200089101B /* AttachmentIDs.swift */; };
 		14C8FF6F2EABA4250089101B /* AttachmentIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8FF6C2EABA4200089101B /* AttachmentIDs.swift */; };
@@ -288,6 +295,7 @@
 		145E0F612E9C0F3B00CE6C97 /* HippoVisionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HippoVisionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		146F102A2EA3ACFD00DDDC35 /* HippoAssets */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HippoAssets; sourceTree = "<group>"; };
 		146F102E2EA3AF1000DDDC35 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		147EB27C2EB0781300D9CFB3 /* OperationStatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationStatusBadge.swift; sourceTree = "<group>"; };
 		1494DE702EA72BCE000CD284 /* OperationDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationDetailView.swift; sourceTree = "<group>"; };
 		1494DE7B2EA73205000CD284 /* DetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailHeader.swift; sourceTree = "<group>"; };
 		1494DE7F2EA7321A000CD284 /* AssetSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSection.swift; sourceTree = "<group>"; };
@@ -295,6 +303,12 @@
 		1494DE972EA73359000CD284 /* SectionTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTitle.swift; sourceTree = "<group>"; };
 		1494DE9F2EA7510A000CD284 /* DetailSubPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSubPart.swift; sourceTree = "<group>"; };
 		1494DEA42EA7C851000CD284 /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		14A17F862EB3138D009D16CF /* PatientDetailHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientDetailHeader.swift; sourceTree = "<group>"; };
+		14A17F882EB313E6009D16CF /* OperationInfoSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationInfoSection.swift; sourceTree = "<group>"; };
+		14A17F8A2EB3140B009D16CF /* SurgeonInfoSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurgeonInfoSection.swift; sourceTree = "<group>"; };
+		14A17F8C2EB3146B009D16CF /* OperationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCard.swift; sourceTree = "<group>"; };
+		14A17F8E2EB31480009D16CF /* OperationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationList.swift; sourceTree = "<group>"; };
+		14A17F902EB314AF009D16CF /* EmptyOperationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyOperationView.swift; sourceTree = "<group>"; };
 		14C8FF6C2EABA4200089101B /* AttachmentIDs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentIDs.swift; sourceTree = "<group>"; };
 		14CC75422EA6803800399562 /* TodayOperationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayOperationCard.swift; sourceTree = "<group>"; };
 		14CC75462EA69DE400399562 /* PatientCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientCell.swift; sourceTree = "<group>"; };
@@ -465,6 +479,7 @@
 		1446FBE02EAF29A0000BCF61 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				147EB27C2EB0781300D9CFB3 /* OperationStatusBadge.swift */,
 				14CC754C2EA6A77C00399562 /* OrnamentButton.swift */,
 				1446FBDD2EAF2962000BCF61 /* HippoAlertView.swift */,
 			);
@@ -494,6 +509,10 @@
 		1446FBEB2EAFA45D000BCF61 /* Molecules */ = {
 			isa = PBXGroup;
 			children = (
+				14A17F902EB314AF009D16CF /* EmptyOperationView.swift */,
+				14A17F8C2EB3146B009D16CF /* OperationCard.swift */,
+				14A17F8A2EB3140B009D16CF /* SurgeonInfoSection.swift */,
+				14A17F882EB313E6009D16CF /* OperationInfoSection.swift */,
 				1446FBEC2EAFA471000BCF61 /* FormSection.swift */,
 			);
 			path = Molecules;
@@ -502,6 +521,8 @@
 		1446FBEE2EAFAD45000BCF61 /* Organisms */ = {
 			isa = PBXGroup;
 			children = (
+				14A17F8E2EB31480009D16CF /* OperationList.swift */,
+				14A17F862EB3138D009D16CF /* PatientDetailHeader.swift */,
 				1446FBF12EAFADC5000BCF61 /* PatientInputForm.swift */,
 				1446FBEF2EAFAD56000BCF61 /* PatientInputHeader.swift */,
 			);
@@ -1170,6 +1191,7 @@
 				1446FBAB2EAE6B55000BCF61 /* PatientInfoHeader.swift in Sources */,
 				C050AA4F2EA8201A00352314 /* ImmersiveSceneRuntime.swift in Sources */,
 				1446FB9A2EAE6911000BCF61 /* CircleIconButton.swift in Sources */,
+				14A17F892EB313EA009D16CF /* OperationInfoSection.swift in Sources */,
 				14CC756A2EA6A98700399562 /* OperationDateBadge.swift in Sources */,
 				C0F97AD62EA41FB50063E159 /* PatientLocalDataSource.swift in Sources */,
 				1494DE982EA73359000CD284 /* SectionTitle.swift in Sources */,
@@ -1184,11 +1206,13 @@
 				1494DE7C2EA73205000CD284 /* DetailHeader.swift in Sources */,
 				C046782F2EA00B3A00D160DA /* PatientRepositoryImpl.swift in Sources */,
 				C04678302EA00B3A00D160DA /* PatientRemoteDataSource.swift in Sources */,
+				147EB27D2EB0782100D9CFB3 /* OperationStatusBadge.swift in Sources */,
 				14F6B0342EAAC73F003F28EB /* ImmersiveSurgeryView.swift in Sources */,
 				144254662EAAC44900583CC3 /* StartOperationButton.swift in Sources */,
 				144254342EAA232300583CC3 /* OperationViewModel.swift in Sources */,
 				C04678142EA00B1F00D160DA /* Patient.swift in Sources */,
 				14C8FF6D2EABA4250089101B /* AttachmentIDs.swift in Sources */,
+				14A17F872EB31397009D16CF /* PatientDetailHeader.swift in Sources */,
 				14CC756C2EA6A99300399562 /* PatientGridView.swift in Sources */,
 				14CC755B2EA6A8C700399562 /* SectionHeader.swift in Sources */,
 				C04678172EA00B1F00D160DA /* GetPatient.swift in Sources */,
@@ -1204,6 +1228,7 @@
 				1446FB9E2EAE69AF000BCF61 /* RecordingIndicator.swift in Sources */,
 				C02FFA9D2E9FFF6F00F16742 /* AppModel.swift in Sources */,
 				C0F97A7B2EA3FD370063E159 /* PatientDTO.swift in Sources */,
+				14A17F8B2EB31411009D16CF /* SurgeonInfoSection.swift in Sources */,
 				1494DE852EA73229000CD284 /* AssetImageCard.swift in Sources */,
 				C0F97ACC2EA41D4B0063E159 /* SDOperation.swift in Sources */,
 				C0F97ACD2EA41D4B0063E159 /* SDOperationRecording.swift in Sources */,
@@ -1221,6 +1246,8 @@
 				C0F97B222EA435490063E159 /* CreateOperationCommand.swift in Sources */,
 				C0F97B232EA435490063E159 /* ValidationError.swift in Sources */,
 				1446FBB62EAE6C66000BCF61 /* MenuToggleButton.swift in Sources */,
+				14A17F912EB314B3009D16CF /* EmptyOperationView.swift in Sources */,
+				14A17F8F2EB31482009D16CF /* OperationList.swift in Sources */,
 				C0F97B242EA435490063E159 /* CreatePatientCommand.swift in Sources */,
 				C0F97AE22EA4304D0063E159 /* CreateOperation.swift in Sources */,
 				C046783F2EA00B4A00D160DA /* PatientState.swift in Sources */,
@@ -1230,6 +1257,7 @@
 				1494DEA02EA7510A000CD284 /* DetailSubPart.swift in Sources */,
 				C0F97AB02EA401160063E159 /* OperationDisplayModel.swift in Sources */,
 				1446FBA32EAE6A27000BCF61 /* GlowingCircleButton.swift in Sources */,
+				14A17F8D2EB3146D009D16CF /* OperationCard.swift in Sources */,
 				144254382EAA9FF000583CC3 /* OperationState.swift in Sources */,
 				C0F97B2F2EA439290063E159 /* UpdatePatientCommand.swift in Sources */,
 				1494DE732EA72BCE000CD284 /* OperationDetailView.swift in Sources */,

--- a/Hippo/Applications/VisionApp/HippoVisionApp.swift
+++ b/Hippo/Applications/VisionApp/HippoVisionApp.swift
@@ -23,7 +23,7 @@ struct HippoVisionApp: App {
             PatientInputView()
                 .environment(appModel)
         }
-        .defaultSize(width: 512, height: 700)
+        .windowResizability(.contentSize)
 
         WindowGroup(id: WindowIDs.patientDetail, for: String.self) { $id in
             if let id = id {
@@ -31,6 +31,7 @@ struct HippoVisionApp: App {
                     .environment(appModel)
             }
         }
+        .windowResizability(.contentSize)
 
         WindowGroup(id: WindowIDs.operationDetail, for: OperationContext.self) { $context in
             if let context = context {

--- a/Hippo/Applications/VisionApp/HippoVisionApp.swift
+++ b/Hippo/Applications/VisionApp/HippoVisionApp.swift
@@ -25,6 +25,13 @@ struct HippoVisionApp: App {
         }
         .defaultSize(width: 512, height: 700)
 
+        WindowGroup(id: WindowIDs.patientDetail, for: String.self) { $id in
+            if let id = id {
+                PatientDetailView(patientId: id)
+                    .environment(appModel)
+            }
+        }
+
         WindowGroup(id: WindowIDs.operationDetail, for: OperationContext.self) { $context in
             if let context = context {
                 OperationDetailView(

--- a/Hippo/Features/Vision/Runtime/ImmersiveSceneRuntime.swift
+++ b/Hippo/Features/Vision/Runtime/ImmersiveSceneRuntime.swift
@@ -27,13 +27,13 @@ final class ImmersiveSceneRuntime {
     // RealityView 의 content 관리
     func setupScene(in content: RealityViewContent, attachments: RealityViewAttachments) {
         let anchor1 = AnchorEntity(.head)
-        anchor1.position = [0, 0.45, -1.0]
+        anchor1.position = [0, 0.3, -1.0]
         if let topButton = attachments.entity(for: AttachmentIDs.topToggleButton) {
             anchor1.addChild(topButton)
         }
 
         let anchor2 = AnchorEntity(.head)
-        anchor2.position = [0, -0.45, -1.0] // 시야 아래쪽에 배치
+        anchor2.position = [0, -0.6, -1.0] // 시야 아래쪽에 배치
         if let bottomMenuBar = attachments.entity(for: AttachmentIDs.bottomMenuBar) {
             anchor2.addChild(bottomMenuBar)
         }

--- a/Hippo/Features/Vision/UI/Home/Components/PatientSection/PatientCell.swift
+++ b/Hippo/Features/Vision/UI/Home/Components/PatientSection/PatientCell.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PatientCell: View {
     let patient: PatientDisplayModel
+    let action: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -56,9 +57,10 @@ struct PatientCell: View {
                 .fill(.thinMaterial)
         )
         .hoverEffect(.lift)
+        .onTapGesture { action() }
     }
 }
 
 #Preview {
-    PatientCell(patient: PatientDisplayModel.MockData)
+    PatientCell(patient: PatientDisplayModel.MockData) {}
 }

--- a/Hippo/Features/Vision/UI/Home/Components/PatientSection/PatientGridView.swift
+++ b/Hippo/Features/Vision/UI/Home/Components/PatientSection/PatientGridView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 /// 환자 카드 그리드
 struct PatientGridView: View {
+    @Environment(\.pushWindow) private var pushWindow
+
     let patients: [PatientDisplayModel]
 
     private var columns: [GridItem] {
@@ -18,7 +20,7 @@ struct PatientGridView: View {
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 24) {
             ForEach(patients) { patient in
-                PatientCell(patient: patient)
+                PatientCell(patient: patient) { pushWindow(id: WindowIDs.patientDetail, value: patient.id) }
             }
         }
     }

--- a/Hippo/Features/Vision/UI/Home/Components/TodaySection/TodayOperationCard.swift
+++ b/Hippo/Features/Vision/UI/Home/Components/TodaySection/TodayOperationCard.swift
@@ -28,16 +28,10 @@ struct TodayOperationCard: View {
                     Spacer()
 
                     // 수술 상태 배지 (수술 대기 / 수술 완료)
-                    Text(operation.statusText)
-                        .font(.headline)
-                        .fontWeight(.bold)
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(
-                            Capsule()
-                                .fill(Color(operation.statusColor))
-                        )
+                    OperationStatusBadge(
+                        status: operation.statusText,
+                        color: operation.statusColor
+                    )
                 }
 
                 Text(operation.title)

--- a/Hippo/Features/Vision/UI/Patient/Components/Molecules/EmptyOperationView.swift
+++ b/Hippo/Features/Vision/UI/Patient/Components/Molecules/EmptyOperationView.swift
@@ -1,0 +1,25 @@
+//
+//  EmptyOperationView.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/30/25.
+//
+
+import SwiftUI
+
+struct EmptyOperationView: View {
+    var body: some View {
+        VStack {
+            Text("수술 데이터가 없습니다.")
+                .font(.headline)
+                .foregroundStyle(.primary)
+                .padding(.bottom, 8)
+            Text("수술 준비를 위해 데이터를 입력해주세요.")
+                .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+#Preview {
+    EmptyOperationView()
+}

--- a/Hippo/Features/Vision/UI/Patient/Components/Molecules/OperationCard.swift
+++ b/Hippo/Features/Vision/UI/Patient/Components/Molecules/OperationCard.swift
@@ -1,0 +1,28 @@
+//
+//  OperationCard.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/30/25.
+//
+
+import SwiftUI
+
+struct OperationCard: View {
+    let operation: OperationDisplayModel
+
+    var body: some View {
+        VStack {
+            OperationInfoSection(operation: operation)
+
+            Divider().padding(.vertical, 12)
+
+            SurgeonInfoSection(surgeonName: operation.surgeon)
+        }
+        .glassBackgroundEffect()
+        .padding(.bottom, 28)
+    }
+}
+
+#Preview {
+    OperationCard(operation: OperationDisplayModel.MockData)
+}

--- a/Hippo/Features/Vision/UI/Patient/Components/Molecules/OperationInfoSection.swift
+++ b/Hippo/Features/Vision/UI/Patient/Components/Molecules/OperationInfoSection.swift
@@ -1,0 +1,40 @@
+//
+//  OperationInfoSection.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/30/25.
+//
+
+import SwiftUI
+
+struct OperationInfoSection: View {
+    let operation: OperationDisplayModel
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                OperationStatusBadge(
+                    status: operation.statusText,
+                    color: operation.statusColor
+                )
+                Spacer()
+            }
+            .padding(.bottom)
+
+            Text(operation.title)
+                .font(.largeTitle)
+                .foregroundStyle(.primary)
+                .padding(.bottom, 8)
+
+            Text(operation.date.toOperationDateString())
+                .font(.title2)
+                .foregroundColor(.primary)
+        }
+        .padding(.horizontal, 28)
+        .padding(.top, 28)
+    }
+}
+
+#Preview {
+    OperationInfoSection(operation: OperationDisplayModel.MockData)
+}

--- a/Hippo/Features/Vision/UI/Patient/Components/Molecules/SurgeonInfoSection.swift
+++ b/Hippo/Features/Vision/UI/Patient/Components/Molecules/SurgeonInfoSection.swift
@@ -1,0 +1,33 @@
+//
+//  SurgeonInfoSection.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/30/25.
+//
+
+import SwiftUI
+
+struct SurgeonInfoSection: View {
+    let surgeonName: String
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text("집도의")
+                    .font(.title2)
+                    .foregroundStyle(.tertiary)
+                Text(surgeonName)
+                    .font(.title)
+                    .foregroundStyle(.primary)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 28)
+        .padding(.bottom, 28)
+    }
+}
+
+#Preview {
+    SurgeonInfoSection(surgeonName: "김외과")
+}

--- a/Hippo/Features/Vision/UI/Patient/Components/Organisms/OperationList.swift
+++ b/Hippo/Features/Vision/UI/Patient/Components/Organisms/OperationList.swift
@@ -1,0 +1,31 @@
+//
+//  OperationList.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/30/25.
+//
+
+import SwiftUI
+
+struct OperationList: View {
+    let operations: [OperationDisplayModel]
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .center) {
+                Spacer().frame(height: 40)
+                ForEach(operations) { operation in
+                    OperationCard(operation: operation)
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+    }
+}
+
+#Preview {
+    OperationList(operations: [
+        OperationDisplayModel.MockData,
+        OperationDisplayModel.MockData,
+    ])
+}

--- a/Hippo/Features/Vision/UI/Patient/Components/Organisms/PatientDetailHeader.swift
+++ b/Hippo/Features/Vision/UI/Patient/Components/Organisms/PatientDetailHeader.swift
@@ -1,0 +1,52 @@
+//
+//  PatientDetailHeader.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/30/25.
+//
+
+import SwiftUI
+
+struct PatientDetailHeader: View {
+    let name: String
+    let gender: String
+    let ageText: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack {
+            Button(action: onDismiss) {
+                Image(systemName: "chevron.left")
+            }
+            .buttonBorderShape(.circle)
+            .glassBackgroundEffect()
+
+            Spacer()
+
+            HStack {
+                Text(name)
+                    .font(.title)
+                    .foregroundStyle(.primary)
+
+                Spacer().frame(width: 8)
+
+                Text("\(gender) / \(ageText)")
+            }
+
+            Spacer()
+
+            Color.clear
+                .frame(width: 44, height: 44)
+        }
+        .padding(.top, 36)
+    }
+}
+
+#Preview {
+    PatientDetailHeader(
+        name: "김환자",
+        gender: "남",
+        ageText: "45세",
+        onDismiss: {}
+    )
+}

--- a/Hippo/Features/Vision/UI/Patient/PatientDetailView.swift
+++ b/Hippo/Features/Vision/UI/Patient/PatientDetailView.swift
@@ -8,20 +8,48 @@
 import SwiftUI
 
 struct PatientDetailView: View {
+    @Environment(\.dismiss) private var dismiss
     @State private var viewModel = PatientViewModel()
-    
+
     let patientId: String
+
+    private var patient: PatientDisplayModel {
+        viewModel.patient ?? PatientDisplayModel.MockData
+    }
 
     var body: some View {
         VStack {
-            
+            PatientDetailHeader(
+                name: patient.name,
+                gender: patient.gender,
+                ageText: patient.ageText,
+                onDismiss: { dismiss() }
+            )
+
+            Spacer()
+
+            if patient.operationCount != 0 {
+                OperationList(operations: patient.operations)
+            } else {
+                EmptyOperationView()
+            }
+
+            Spacer()
         }
+        .padding(.horizontal, 32)
+        .frame(minWidth: 512, maxWidth: 512, minHeight: 620, maxHeight: 1020)
+        .glassBackgroundEffect(displayMode: .always)
         .task {
             await viewModel.load(patientID: patientId)
+        }
+        .ornament(attachmentAnchor: .scene(.bottom)) {
+            OrnamentButton {}
+                .systemName("long.text.page.and.pencil")
+                .content("수술 추가")
         }
     }
 }
 
 #Preview {
-    PatientDetailView(patientId: "12345678")
+    PatientDetailView(patientId: "sample-001")
 }

--- a/Hippo/Features/Vision/UI/Patient/PatientDetailView.swift
+++ b/Hippo/Features/Vision/UI/Patient/PatientDetailView.swift
@@ -1,0 +1,27 @@
+//
+//  PatientDetailView.swift
+//  HippoVision
+//
+//  Created by 김현기 on 10/27/25.
+//
+
+import SwiftUI
+
+struct PatientDetailView: View {
+    @State private var viewModel = PatientViewModel()
+    
+    let patientId: String
+
+    var body: some View {
+        VStack {
+            
+        }
+        .task {
+            await viewModel.load(patientID: patientId)
+        }
+    }
+}
+
+#Preview {
+    PatientDetailView(patientId: "12345678")
+}

--- a/Hippo/Features/Vision/UI/Patient/PatientInputView.swift
+++ b/Hippo/Features/Vision/UI/Patient/PatientInputView.swift
@@ -28,6 +28,7 @@ struct PatientInputView: View {
             Spacer()
         }
         .padding(.horizontal, 32)
+//        .frame(minWidth: 580, maxWidth: 1020, minHeight: 760, maxHeight: 1020)
         .frame(width: 512, height: 700)
         .glassBackgroundEffect(displayMode: .always)
         .ornament(attachmentAnchor: .scene(.bottom)) {

--- a/Hippo/Features/Vision/UI/Patient/PatientViewModel.swift
+++ b/Hippo/Features/Vision/UI/Patient/PatientViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  PatientViewModel.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/27/25.
+//
+
+import Dependencies
+import os.log
+import SwiftUI
+
+@MainActor
+@Observable
+public class PatientViewModel {
+    // MARK: - Dependencies
+
+    @ObservationIgnored
+    @Dependency(\.getPatient) private var getPatient
+
+    // MARK: - Logger
+
+    private let logger = Logger(subsystem: "com.television.hippo", category: "PatientViewModel")
+
+    // MARK: - State
+
+    public var patient: PatientDisplayModel?
+
+    // MARK: - Action
+
+    public func load(patientID: String) async {
+        do {
+            let p = try await getPatient.run(patientID)
+            logger.debug("🐛 Loaded \(p.name) from repository")
+
+            let patientDisplayModel = p.toDisplayModel()
+            patient = patientDisplayModel
+
+        } catch {
+            logger.error("Failed to load patient with ID \(patientID), error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Hippo/Features/Vision/UI/Shared/OperationStatusBadge.swift
+++ b/Hippo/Features/Vision/UI/Shared/OperationStatusBadge.swift
@@ -1,0 +1,47 @@
+//
+//  OperationStatusBadge.swift
+//  Hippo
+//
+//  Created by 김현기 on 10/28/25.
+//
+
+import SwiftUI
+
+/// 텍스트와 배경색을 받아 캡슐 형태의 배지를 표시하는
+struct OperationStatusBadge: View {
+    // MARK: - Inputs (의존성 최소화)
+
+    let status: String
+    let color: String
+
+    // (선택 사항) 텍스트 색상도 커스텀할 수 있게
+    // 기본값을 지정하여 Input으로 뺄 수 있습니다.
+    var textColor: Color = .primary
+
+    var body: some View {
+        Text(status)
+            .font(.headline)
+            .fontWeight(.bold)
+            .foregroundStyle(textColor)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(Color(color))
+            )
+    }
+}
+
+// MARK: - Preview (독립적 테스트)
+
+#Preview {
+    VStack(spacing: 16) {
+        // 컴포넌트가 ViewModel이나 'operation' 객체 없이도
+        // 완벽하게 렌더링되는지 테스트합니다.
+
+        OperationStatusBadge(status: "수술 중", color: "HippoPrimary")
+        OperationStatusBadge(status: "대기 중", color: "HippoPrimary", textColor: .
+            white)
+    }
+    .padding()
+}

--- a/Hippo/Shared/Presentation/Home/DisplayModels/PatientDisplayModel.swift
+++ b/Hippo/Shared/Presentation/Home/DisplayModels/PatientDisplayModel.swift
@@ -48,6 +48,36 @@ public struct PatientDisplayModel: Identifiable, Equatable, Sendable {
         self.updatedAtText = updatedAtText
     }
 
+    static let operation1 = OperationDisplayModel(
+        id: "sample-op-001",
+        title: "고관절 전치환술",
+        diagnosis: "퇴행성 관절염",
+        surgeon: "Dr. 홍길동",
+        date: Date(),
+        dateText: "2024.06.20",
+        details: "환자는 70대 남성으로, 좌측 고관절의 심한 퇴행성 변화로 인해 전치환술을 시행하였습니다. 수술은 성공적으로 마무리되었으며, 현재 재활 치료 중입니다.",
+        status: .planned,
+        statusText: "수술 대기",
+        statusColor: "HippoRed",
+        assets: [],
+        assetCount: 0,
+    )
+
+    static let operation2 = OperationDisplayModel(
+        id: "sample-op-002",
+        title: "간암 절제술",
+        diagnosis: "간세포암",
+        surgeon: "Dr. 이순신",
+        date: Date(),
+        dateText: "2024.05.15",
+        details: "환자는 70대 남성으로, 좌측 고관절의 심한 퇴행성 변화로 인해 전치환술을 시행하였습니다. 수술은 성공적으로 마무리되었으며, 현재 재활 치료 중입니다.",
+        status: .completed,
+        statusText: "수술 완료",
+        statusColor: "HippoBlack",
+        assets: [],
+        assetCount: 0,
+    )
+
     // SAMPLE
     public static let MockData = PatientDisplayModel(
         id: "sample-001",
@@ -58,8 +88,8 @@ public struct PatientDisplayModel: Identifiable, Equatable, Sendable {
         age: 45,
         ageText: "45세",
         birthDateText: "1979.03.15",
-        operations: [],
-        operationCount: 1,
+        operations: [operation1, operation2],
+        operationCount: 2,
         latestOperation: nil,
         updatedAt: Date(),
         updatedAtText: "방금 전"


### PR DESCRIPTION
## 📕 Issue Number

Close #4 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- **PatientDetailView Hi-Fi UI 구현**
- PatientDetailView 관련 구조 신규 생성 (PatientDetailView.swift, PatientDetailHeader.swift 등)
- PatientViewModel 생성 및 로딩/상태 관리 기능 추가
- OperationStatusBadge 컴포넌트 구현
- 환자의 수술 리스트(OperationList), 개별 수술 카드(OperationCard), 집도의 정보(SurgeonInfoSection), 수술 정보(OperationInfoSection) 등 UI 컴포넌트 분리 및 상세화
- 수술 데이터가 없을 때 EmptyOperationView 표시 로직 추가
- PatientCell, PatientGridView 내 patientDetail 창 오픈 로직 연동 및 액션 추가 (`pushWindow` 환경값 활용)
- HippoVisionApp에서 PatientDetailView를 WindowGroup으로 제공하는 창 분리/관리 기능 구현
- 코드 내 windowResizability, glassBackgroundEffect 등 VisionOS 대응 스타일 적용
- UI 및 데이터 흐름 개선에 따라 기존 PatientInputView 사이즈 및 접근 방식 일부 변경
- ImmersiveSceneRuntime 등 관련 코드 실행 위치/anchor 수정
- MockData 활용하여 프리뷰 및 테스트 가능하도록 설정
- 전체적으로 MVVM 패턴 강화, 코드 분리 및 테스트 용이성 증대


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

<img width="300" alt="2025-10-30_12-39-54" src="https://github.com/user-attachments/assets/1c69f92b-9a25-42f9-92e4-66793ed2f740" />
<img width="300" alt="2025-10-30_12-41-24" src="https://github.com/user-attachments/assets/a2c5d96d-46cd-4134-a839-15ef83d7a662" />



## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- **새로 추가된 UI 컴포넌트 간 연계성, 데이터 흐름** (ViewModel과 View 사이의 바인딩, async 로딩, mock 데이터 fallback 등)
- **WindowGroup 및 창 관리 로직 수정 내역** (직접 `pushWindow` 호출 및 창 분리)
- **새로 생성된 파일 및 변경된 파일의 역할과 레이어** (예: Molecules/Organisms/Components 폴더 구조)
- **코드 사이즈 및 중복 검사** (컴포넌트 분리 과정에서 유사 UI, 스타일 중복 여부)
- **Patient의 operationCount 및 데이터 상태에 따른 분기 처리 로직**
- **Style/Effect 관련 코드(VisionOS 대응 효과, 패딩, 배경 등) UI 일관성 유지 여부**
- **모든 프리뷰 관련 코드에 실제 데이터와 mock 데이터 활용 최적화**
- **기존 PatientInputView와의 통합 및 사이즈/스타일 변경 내역**

<br><br>
