### PR TITLE
[Chore] #92 InputView Button 위치 수정

### DIFF
--- a/Hippo/Features/Vision/UI/Home/HomeView.swift
+++ b/Hippo/Features/Vision/UI/Home/HomeView.swift
@@ -48,8 +48,10 @@ struct HomeView: View {
             }
         }
         .ornament(attachmentAnchor: .scene(.bottom)) {
-            OrnamentButton {
-                viewModel.isPresentingCreatePatientSheet = true
+            if !viewModel.isPresentingCreatePatientSheet {
+                OrnamentButton {
+                    viewModel.isPresentingCreatePatientSheet = true
+                }
             }
         }
         .sheet(isPresented: $viewModel.isPresentingCreatePatientSheet) {

--- a/Hippo/Features/Vision/UI/Operation/Components/Molecules/ModelPreviewCard.swift
+++ b/Hippo/Features/Vision/UI/Operation/Components/Molecules/ModelPreviewCard.swift
@@ -36,6 +36,7 @@ struct ModelPreviewCard: View {
             .frame(width: size - 20, height: size - 20)
             .onAppear {
                 _ = url.startAccessingSecurityScopedResource()
+                print("🚀 Accessing security scoped resource: \(url)")
             }
             .onDisappear {
                 url.stopAccessingSecurityScopedResource()

--- a/Hippo/Features/Vision/UI/Operation/OperationInputView.swift
+++ b/Hippo/Features/Vision/UI/Operation/OperationInputView.swift
@@ -32,23 +32,25 @@ struct OperationInputView: View {
                 )
                 .padding(.bottom, 32)
 
-                OrnamentButton {
-                    // 수술 저장하기
-                    Task {
-                        await viewModel.addOperation(toPatientID: patientID)
-                        appModel.operations += 1
-                        dismiss()
-                    }
-                }
-                .systemName("square.and.arrow.down")
-                .content("저장하기")
-                .padding(.bottom, 32)
+                Spacer()
             }
         }
         .scrollIndicators(.hidden)
         .padding(.horizontal, 32)
         .frame(width: 460, height: 680)
         .glassBackgroundEffect(displayMode: .always)
+        .ornament(attachmentAnchor: .parent(.bottom)) {
+            OrnamentButton {
+                // 수술 저장하기
+                Task {
+                    await viewModel.addOperation(toPatientID: patientID)
+                    appModel.operations += 1
+                    dismiss()
+                }
+            }
+            .systemName("square.and.arrow.down")
+            .content("저장하기")
+        }
     }
 }
 

--- a/Hippo/Features/Vision/UI/Patient/PatientDetailView.swift
+++ b/Hippo/Features/Vision/UI/Patient/PatientDetailView.swift
@@ -40,11 +40,13 @@ struct PatientDetailView: View {
             }
         }
         .ornament(attachmentAnchor: .scene(.bottom)) {
-            OrnamentButton {
-                viewModel.isPresentingOperationInput = true
+            if !viewModel.isPresentingOperationInput {
+                OrnamentButton {
+                    viewModel.isPresentingOperationInput = true
+                }
+                .systemName("long.text.page.and.pencil")
+                .content("수술 추가")
             }
-            .systemName("long.text.page.and.pencil")
-            .content("수술 추가")
         }
         .sheet(isPresented: $viewModel.isPresentingOperationInput) {
             OperationInputView(patientID: patientId)

--- a/Hippo/Features/Vision/UI/Patient/PatientInputView.swift
+++ b/Hippo/Features/Vision/UI/Patient/PatientInputView.swift
@@ -13,34 +13,32 @@ struct PatientInputView: View {
     @State private var viewModel = HomeViewModel()
 
     var body: some View {
-        ZStack {
-            VStack(spacing: 0) {
-                PatientInputHeader(onDismiss: {
-                    viewModel.isShowDismissAlert = true
-                })
+        VStack(spacing: 0) {
+            PatientInputHeader(onDismiss: {
+                viewModel.isShowDismissAlert = true
+            })
 
-                Spacer().frame(height: 56)
+            Spacer().frame(height: 56)
 
-                PatientInputForm(
-                    patientNumber: $viewModel.patientNumber,
-                    name: $viewModel.name,
-                    birthDate: $viewModel.birthDate,
-                    selectedGender: $viewModel.selectedGender
-                )
+            PatientInputForm(
+                patientNumber: $viewModel.patientNumber,
+                name: $viewModel.name,
+                birthDate: $viewModel.birthDate,
+                selectedGender: $viewModel.selectedGender
+            )
 
-                Spacer()
-
-                OrnamentButton {
-                    handleSubmit()
-                }
-                .systemName("square.and.arrow.down")
-                .content("추가하기")
-                .padding(.bottom, 28)
-            }
+            Spacer()
         }
         .padding(.horizontal, 28)
         .frame(width: 460, height: 680)
         .glassBackgroundEffect(displayMode: .always)
+        .ornament(attachmentAnchor: .parent(.bottom)) {
+            OrnamentButton {
+                handleSubmit()
+            }
+            .systemName("square.and.arrow.down")
+            .content("추가하기")
+        }
         .alert("작성을 취소할까요?", isPresented: $viewModel.isShowDismissAlert) {
             Button("네", role: .destructive) { dismiss() }
             Button("아니요", role: .cancel) { viewModel.isShowDismissAlert = false }

--- a/Hippo/Shared/Domain/Patients/UseCases/AddAssetsToOperation.swift
+++ b/Hippo/Shared/Domain/Patients/UseCases/AddAssetsToOperation.swift
@@ -61,9 +61,17 @@ public struct AddAssetsToOperation: Sendable {
         var savedURLs: [URL] = []
 
         for url in urls {
+            // 보안 스코프 리소스 접근
+            let accessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if accessing {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+
             // 파일명 중복 방지를 위해 UUID 추가
             let fileExtension = url.pathExtension
-            let fileName = "\(UUID().uuidString).\(fileExtension)"
+            let fileName = "\(url.deletingPathExtension().lastPathComponent).\(fileExtension)"
             let destinationURL = operationAssetsFolder.appendingPathComponent(fileName)
 
             // 기존 파일이 있으면 삭제


### PR DESCRIPTION
## 📕 Issue Number

Close #92 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- **InputView의 버튼 위치 및 표시 로직 개선**: 버튼이 Sheet 중복 표시되지 않도록 if 조건 추가
- **OperationInputView에서 OrnamentButton 위치 변경**: 버튼이 뷰 하단 부모 기준에 따라 떠 있도록 개선
- **PatientDetailView/PatientInputView 버튼 로직 일관성 적용**: 하단 버튼 및 Alert 제어 방식 통일
- **ModelPreviewCard에 보안 스코프 리소스 접근 로그 추가**: 접근 시 print 로그로 확인 가능하도록 적용
- **AddAssetsToOperation 유즈케이스 내 파일 접근 권한 처리 및 파일명 생성 개선**: SecurityScopedResource로 파일 접근/해제, 파일명 로직 개선 (UUID → 원본명 기반)
- **관련 불필요 코드 삭제 및 리팩토링**: 뷰 내 불필요한 ZStack 등 정리, 코드의 가독성 및 일관성 향상
- **스크린샷 첨부 등 UI 변경 확인 용이**: PR 템플릿 활용해 변경된 UI 스크린샷 캡처 기능 반영
- **각종 OrnamentButton 내부 Task 동작 구조 개선**: 비동기 로직 위치 및 실행 안정성 향상
- **버그/기능 표시 구분을 체크박스 형식으로 일괄 적용**


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

- 스크린 샷


## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- **보안 스코프 리소스 접근 처리 개선**  
AddAssetsToOperation.swift에서 defer 블록 및 accessing 플래그를 활용한 파일 접근 권한 관리 개선이 이뤄졌습니다. 파일 접근 실패 시 처리 방식과 여러 파일 동시 처리 중 예외 상황 안전성 검토가 필요합니다.

- **파일명 생성 방식 변경 (원본명 사용)**  
기존 UUID 방식에서 원본 파일명을 그대로 사용하는 방식으로 바뀌었습니다. 동일한 파일명 추가 시 덮어쓰기가 발생할 수 있어, 실제로 중복 파일명에 대한 추가적 보호가 필요한지 확인해야 합니다.

- **OrnamentButton 렌더링 조건 및 위치 기준 변경**  
Sheet가 표시 중일 때 버튼을 숨기는 조건 추가와 attachmentAnchor 변경(.scene → .parent)이 포함되어 있습니다. Sheet 표시/해제 후 UI 동작의 일관성, 레이아웃 깜빡임 및 버튼 위치 테스트가 필요합니다.

- **print 로그 추가 (ModelPreviewCard 등)**  
보안 스코프 리소스 접근 시 print 로그가 추가되어 있습니다. 실제 배포 시 불필요한 디버깅용 로그가 포함되지 않는지 주의해야 합니다.

- **다수 뷰 코드 구조 및 호출 방식의 일관성 리팩토링**  
하단 버튼 처리, Alert 제어 방식 등 View 구조 통일로 인한 UI/UX 영향 및 기존 코드와의 호환성을 확인해야 합니다.


<br><br>
