### PR TITLE
[Feat/Refactor] #21 #65 OpacityControlPanel UI 및 기능 구현 완성

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -138,6 +138,8 @@
 		278623332EB790CE00F97BE3 /* AssetListScrollCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278623322EB790CE00F97BE3 /* AssetListScrollCard.swift */; };
 		278623342EB790CE00F97BE3 /* AssetListScrollCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278623322EB790CE00F97BE3 /* AssetListScrollCard.swift */; };
 		278623352EB790CE00F97BE3 /* AssetListScrollCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278623322EB790CE00F97BE3 /* AssetListScrollCard.swift */; };
+		278623372EB8EB7800F97BE3 /* OpacityControlSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278623362EB8EB7800F97BE3 /* OpacityControlSlider.swift */; };
+		278623382EB8EB7800F97BE3 /* OpacityControlSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278623362EB8EB7800F97BE3 /* OpacityControlSlider.swift */; };
 		278F28B92EB3874800DF2F73 /* GlowingCapsuleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278F28B82EB3874500DF2F73 /* GlowingCapsuleButton.swift */; };
 		278F28BB2EB3874800DF2F73 /* GlowingCapsuleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278F28B82EB3874500DF2F73 /* GlowingCapsuleButton.swift */; };
 		278F28BD2EB3877300DF2F73 /* AssetListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278F28BC2EB3877200DF2F73 /* AssetListView.swift */; };
@@ -392,6 +394,7 @@
 		272BD1B42EADE1DE00C83F81 /* HeadPose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadPose.swift; sourceTree = "<group>"; };
 		2786232E2EB78F2900F97BE3 /* AssetListScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetListScrollView.swift; sourceTree = "<group>"; };
 		278623322EB790CE00F97BE3 /* AssetListScrollCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetListScrollCard.swift; sourceTree = "<group>"; };
+		278623362EB8EB7800F97BE3 /* OpacityControlSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpacityControlSlider.swift; sourceTree = "<group>"; };
 		278F28B82EB3874500DF2F73 /* GlowingCapsuleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlowingCapsuleButton.swift; sourceTree = "<group>"; };
 		278F28BC2EB3877200DF2F73 /* AssetListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetListView.swift; sourceTree = "<group>"; };
 		27AD7AC32EB4948A00E84809 /* LayerEyeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerEyeButton.swift; sourceTree = "<group>"; };
@@ -584,6 +587,7 @@
 				1446FBB82EAE7705000BCF61 /* SurgeryControlBar.swift */,
 				27AD7AE32EB5BEA400E84809 /* OpacityControlPanelHeader.swift */,
 				2786232E2EB78F2900F97BE3 /* AssetListScrollView.swift */,
+				278623362EB8EB7800F97BE3 /* OpacityControlSlider.swift */,
 			);
 			path = Organisms;
 			sourceTree = "<group>";
@@ -1469,6 +1473,7 @@
 				14A17F972EB34F46009D16CF /* OperationInputHeader.swift in Sources */,
 				C0F97ADA2EA420E10063E159 /* DataDependencies.swift in Sources */,
 				14DE513F2EB60E610027D9A0 /* FileAttachmentSection.swift in Sources */,
+				278623372EB8EB7800F97BE3 /* OpacityControlSlider.swift in Sources */,
 				1446FBED2EAFA477000BCF61 /* FormSection.swift in Sources */,
 				278F28BD2EB3877300DF2F73 /* AssetListView.swift in Sources */,
 				C0F97A8E2EA3FDF50063E159 /* DeleteOperation.swift in Sources */,
@@ -1557,6 +1562,7 @@
 				27AD7ADD2EB5BA2E00E84809 /* OpacityControlPanelButton.swift in Sources */,
 				1446FBA02EAE69AF000BCF61 /* RecordingIndicator.swift in Sources */,
 				C046780C2EA00B1F00D160DA /* ListPatients.swift in Sources */,
+				278623382EB8EB7800F97BE3 /* OpacityControlSlider.swift in Sources */,
 				C046780D2EA00B1F00D160DA /* PatientRepository.swift in Sources */,
 				C0F97B002EA430880063E159 /* Gender.swift in Sources */,
 				C050AA3B2EA8197E00352314 /* ImmersiveIDs.swift in Sources */,

--- a/Hippo/Features/Vision/UI/Immersive/Components/Organisms/OpacityControlSlider.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Components/Organisms/OpacityControlSlider.swift
@@ -11,18 +11,31 @@ struct OpacityControlSlider: View {
     
     @Binding var currentOpacity: Float
     var selectedLayerIDS: Set<String>
+    var isMixed: Bool
+    
+    private var sliderBinding: Binding<Float> {
+        Binding<Float>(
+            get: {
+                return isMixed ? 0.0 : currentOpacity
+            },
+            set: { newValue in
+                currentOpacity = newValue
+            }
+        )
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center ,spacing: 10) {
+            HStack(alignment: .center, spacing: 10) {
                 Text("불투명도")
                     .font(.headline)
-                Text("\(Int(currentOpacity * 100))%")
+                Text(isMixed ? "Mixed" : "\(Int(currentOpacity * 100))%")
                     .font(.title)
+                    .animation(.none, value: isMixed)
             }
             .foregroundStyle(.secondary)
             
-            Slider(value: $currentOpacity, in: 0.0...1.0) {
+            Slider(value: sliderBinding, in: 0.0...1.0) {
                 Text("Opacity")
             }
         }
@@ -40,12 +53,10 @@ struct OpacityControlSlider: View {
 #Preview {
     @Previewable @State var previewOpacity: Float = 0.75
     
-    
-    
-    
     OpacityControlSlider(
         currentOpacity: $previewOpacity,
-        selectedLayerIDS: ["layer_id_1"] // 비어있지 않은 Set
+        selectedLayerIDS: ["layer_id_1"],
+        isMixed: false
     )
 }
 

--- a/Hippo/Features/Vision/UI/Immersive/Components/Organisms/OpacityControlSlider.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Components/Organisms/OpacityControlSlider.swift
@@ -1,0 +1,52 @@
+//
+//  OpacityControlSlider.swift
+//  HippoVision
+//
+//  Created by yunsly on 11/3/25.
+//
+
+import SwiftUI
+
+struct OpacityControlSlider: View {
+    
+    @Binding var currentOpacity: Float
+    var selectedLayerIDS: Set<String>
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center ,spacing: 10) {
+                Text("불투명도")
+                    .font(.headline)
+                Text("\(Int(currentOpacity * 100))%")
+                    .font(.title)
+            }
+            .foregroundStyle(.secondary)
+            
+            Slider(value: $currentOpacity, in: 0.0...1.0) {
+                Text("Opacity")
+            }
+        }
+        .padding(.horizontal, 40)
+        .padding(.vertical, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 200)
+                .fill(.quaternary)
+        )
+        .frame(maxWidth: .infinity)
+        .disabled(selectedLayerIDS.isEmpty)
+    }
+}
+
+#Preview {
+    @Previewable @State var previewOpacity: Float = 0.75
+    
+    
+    
+    
+    OpacityControlSlider(
+        currentOpacity: $previewOpacity,
+        selectedLayerIDS: ["layer_id_1"] // 비어있지 않은 Set
+    )
+}
+
+

--- a/Hippo/Features/Vision/UI/Immersive/OpacityControlPanel.swift
+++ b/Hippo/Features/Vision/UI/Immersive/OpacityControlPanel.swift
@@ -39,7 +39,8 @@ struct OpacityControlPanel: View {
             // 투명도 슬라이더
             OpacityControlSlider(
                 currentOpacity: $viewModel.currentOpacity,
-                selectedLayerIDS: viewModel.selectedLayerIDs
+                selectedLayerIDS: viewModel.selectedLayerIDs,
+                isMixed: viewModel.isMixed
             )
             
             // 2. 레이어 버튼 그리드

--- a/Hippo/Features/Vision/UI/Immersive/OpacityControlPanel.swift
+++ b/Hippo/Features/Vision/UI/Immersive/OpacityControlPanel.swift
@@ -10,42 +10,37 @@ import RealityKit
 
 struct OpacityControlPanel: View {
     
-    var viewModel: OpacityControlViewModel
+    @Bindable var viewModel: OpacityControlViewModel
     
-    @State private var selectedLayerIDs: Set<String> = []
-    
-    // Grid 레이아웃 설정 (3열)
+    // Grid 레이아웃 설정 (4열)
     private let columns: [GridItem] = [
+        GridItem(.flexible()),
         GridItem(.flexible()),
         GridItem(.flexible()),
         GridItem(.flexible())
     ]
     
-    private var isAllSelected: Bool {
-        !viewModel.layers.isEmpty && selectedLayerIDs.count == viewModel.layers.count
-    }
-    
     var body: some View {
         VStack {
             OpacityControlPanelHeader(
-                isAllSelected: isAllSelected,
+                isAllSelected: viewModel.isAllSelected,
                 isAllVisible: viewModel.isAllVisible,
                 onDeleteTapped: {
                     viewModel.deleteSelectedEntity()
                 },
                 onSelectAllToggle: { shouldSelectAll in
-                    if shouldSelectAll {
-                        selectedLayerIDs = Set(viewModel.layers.map { $0.id })
-                    } else {
-                        selectedLayerIDs.removeAll()
-                    }
+                    viewModel.selectAllLayers(shouldSelectAll: shouldSelectAll)
                 },
                 onShowAllToggle: {_ in
                     viewModel.setVisibilityForAll(to: !viewModel.isAllVisible)
                 }
             )
             
-            // TODO: 투명도 슬라이더 (요청대로 일단 보류)
+            // 투명도 슬라이더
+            OpacityControlSlider(
+                currentOpacity: $viewModel.currentOpacity,
+                selectedLayerIDS: viewModel.selectedLayerIDs
+            )
             
             // 2. 레이어 버튼 그리드
             if viewModel.hasAnyLayers {
@@ -55,14 +50,10 @@ struct OpacityControlPanel: View {
                             LayerButton(
                                 title: layer.name,
                                 opacity: layer.opacity,
-                                isSelected: selectedLayerIDs.contains(layer.id),
+                                isSelected: viewModel.selectedLayerIDs.contains(layer.id),
                                 isVisible: layer.isVisible,
                                 onSelect: { shouldSelect in
-                                    if shouldSelect {
-                                        selectedLayerIDs.insert(layer.id)
-                                    } else {
-                                        selectedLayerIDs.remove(layer.id)
-                                    }
+                                    viewModel.selectLayer(id: layer.id, shouldSelect: shouldSelect)
                                 },
                                 onEyeToggle: { _ in
                                     viewModel.toggleVisibility(for: layer.id)
@@ -85,9 +76,8 @@ struct OpacityControlPanel: View {
         }
         .onChange(of: viewModel.runtime.selectedEntity) {
             viewModel.reloadLayers()
-            selectedLayerIDs.removeAll() // 선택 상태 초기화
         }
-        .frame(width: 500, height: 522)
+        .frame(width: 658, height: 522)
         .padding()
         .glassBackgroundEffect()
     }

--- a/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
+++ b/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
@@ -32,6 +32,25 @@ final class OpacityControlViewModel {
         !layers.isEmpty
     }
     
+    // Opacity 조절용 변수
+    var selectedLayerIDs: Set<String> = []
+    var currentOpacity: Float {
+            get {
+                guard let firstSelectedID = selectedLayerIDs.first,
+                      let layer = layers.first(where: { $0.id == firstSelectedID }) else {
+                    return 1.0
+                }
+                return layer.opacity
+            }
+            set {
+                setOpacity(for: Array(selectedLayerIDs), opacity: newValue)
+            }
+        }
+    
+    var isAllSelected: Bool {
+        !layers.isEmpty && selectedLayerIDs.count == layers.count
+    }
+    
     init(runtime: ImmersiveSceneRuntime) {
         self.runtime = runtime
     }
@@ -55,6 +74,7 @@ final class OpacityControlViewModel {
                          isVisible: e.isEnabled,
                          opacity: currentOpacity)
         }
+        selectedLayerIDs.removeAll()
     }
     
     private func collectLeafNodes(from entity: Entity) -> [Entity] {
@@ -77,6 +97,23 @@ final class OpacityControlViewModel {
     
     
     // MARK: -- 선택된 Layer 들의 visibility / Opacity 조정
+    
+    // 선택 상태 관리
+    func selectLayer(id: String, shouldSelect: Bool) {
+        if shouldSelect {
+            selectedLayerIDs.insert(id)
+        } else {
+            selectedLayerIDs.remove(id)
+        }
+    }
+    
+    func selectAllLayers(shouldSelectAll: Bool) {
+        if shouldSelectAll {
+            selectedLayerIDs = Set(layers.map { $0.id })
+        } else {
+            selectedLayerIDs.removeAll()
+        }
+    }
     
     // 선택된 layer 의 visibility 설정
     func toggleVisibility(for partID: Layer.ID) {

--- a/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
+++ b/Hippo/Features/Vision/UI/Immersive/OpacityControlViewModel.swift
@@ -35,20 +35,30 @@ final class OpacityControlViewModel {
     // Opacity 조절용 변수
     var selectedLayerIDs: Set<String> = []
     var currentOpacity: Float {
-            get {
-                guard let firstSelectedID = selectedLayerIDs.first,
-                      let layer = layers.first(where: { $0.id == firstSelectedID }) else {
-                    return 1.0
-                }
-                return layer.opacity
+        get {
+            guard let firstSelectedID = selectedLayerIDs.first,
+                  let layer = layers.first(where: { $0.id == firstSelectedID }) else {
+                return 1.0
             }
-            set {
-                setOpacity(for: Array(selectedLayerIDs), opacity: newValue)
-            }
+            return layer.opacity
         }
+        set {
+            setOpacity(for: Array(selectedLayerIDs), opacity: newValue)
+        }
+    }
     
     var isAllSelected: Bool {
         !layers.isEmpty && selectedLayerIDs.count == layers.count
+    }
+    
+    var isMixed: Bool {
+        let selectedLayers = layers.filter { selectedLayerIDs.contains($0.id) }
+        guard selectedLayers.count > 1 else {
+            return false
+        }
+        
+        let uniqueOpacities = Set(selectedLayers.map { $0.opacity })
+        return uniqueOpacities.count > 1
     }
     
     init(runtime: ImmersiveSceneRuntime) {


### PR DESCRIPTION
## 📕 Issue Number

Close #65 
Close #21 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역
1. OpacityControlSlider 컴포넌트 추가
2. OpacityControlPanel 에서 소유하던 selectedLayerIDs -> OpacityControlPanelViewModel로 이전하여 책임 분리


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

[- 스크린 샷](https://github.com/user-attachments/assets/8e52b72a-3287-4df4-a258-d337a32bd66a)





## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 현재 AssetListScrollCard 선택시 박스가 크기가 유동적입니다. 코드 상으로는 문제가 없는데 흑흑. 추후 원인 발견시 수정하겠습니다.
  (영상 보면 간 모델과 로봇 모델 선택 시, 생성하기 버튼이 가려지는 정도가 다름)
- 불투명도 조정 관련해서 아래 사항 논의가 필요할 것 같습니다.
    1) 선택 취소 기능의 필요 : 선택한 레이어를 초기화하는 트리거가 필요합니다 (굳이 버튼이 아니더라도)
    2) 불투명도가 다른 레이어를 선택했을때 보여주는 값을 어떻게 할 것인지에 대한 가이드도 필요.
        => 해결. 불투명도 다른 레이어 선택 시 Mixed 로 표기 + 슬라이더 위치 0 으로.


https://github.com/user-attachments/assets/57dfd407-3626-4258-a4f6-1cb536346ba4

<br><br>
