### PR TITLE
Feature/#79 StreamingControlView 최소 UI 구현

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0667A5512EB8A34300D7BDF3 /* HomeMockDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667A5502EB8A33400D7BDF3 /* HomeMockDataModel.swift */; };
 		06ADD9CD2EB98B3D0013665B /* OperationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ADD9CC2EB98B3D0013665B /* OperationListView.swift */; };
 		06ADD9D22EB98E730013665B /* PatientInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ADD9D12EB98E730013665B /* PatientInputView.swift */; };
+		06F8CAC12EBA2DF100926483 /* DevicePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F8CAC02EBA2DF100926483 /* DevicePreview.swift */; };
 		144254312EA9FF7800583CC3 /* OperationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144254302EA9FF7800583CC3 /* OperationContext.swift */; };
 		144254332EAA232300583CC3 /* OperationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144254322EAA232300583CC3 /* OperationViewModel.swift */; };
 		144254342EAA232300583CC3 /* OperationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144254322EAA232300583CC3 /* OperationViewModel.swift */; };
@@ -344,6 +345,7 @@
 		0667A5502EB8A33400D7BDF3 /* HomeMockDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMockDataModel.swift; sourceTree = "<group>"; };
 		06ADD9CC2EB98B3D0013665B /* OperationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationListView.swift; sourceTree = "<group>"; };
 		06ADD9D12EB98E730013665B /* PatientInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientInputView.swift; sourceTree = "<group>"; };
+		06F8CAC02EBA2DF100926483 /* DevicePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePreview.swift; sourceTree = "<group>"; };
 		144254302EA9FF7800583CC3 /* OperationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationContext.swift; sourceTree = "<group>"; };
 		144254322EAA232300583CC3 /* OperationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationViewModel.swift; sourceTree = "<group>"; };
 		144254362EAA9FEB00583CC3 /* OperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationState.swift; sourceTree = "<group>"; };
@@ -523,6 +525,7 @@
 			isa = PBXGroup;
 			children = (
 				0667A5492EB8814100D7BDF3 /* StreamingControlView.swift */,
+				06F8CAC02EBA2DF100926483 /* DevicePreview.swift */,
 			);
 			path = StreamingControl;
 			sourceTree = "<group>";
@@ -1759,6 +1762,7 @@
 				1446FBB72EAE6C66000BCF61 /* MenuToggleButton.swift in Sources */,
 				1494DE9A2EA73359000CD284 /* SectionTitle.swift in Sources */,
 				C04678332EA00B3A00D160DA /* PatientRemoteDataSource.swift in Sources */,
+				06F8CAC12EBA2DF100926483 /* DevicePreview.swift in Sources */,
 				C04678472EA00C2700D160DA /* PatientView.swift in Sources */,
 				C0F97A7D2EA3FD370063E159 /* PatientDTO.swift in Sources */,
 				C046781C2EA00B1F00D160DA /* DeletePatient.swift in Sources */,

--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		06ADD9CD2EB98B3D0013665B /* OperationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ADD9CC2EB98B3D0013665B /* OperationListView.swift */; };
 		06ADD9D22EB98E730013665B /* PatientInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ADD9D12EB98E730013665B /* PatientInputView.swift */; };
 		06F8CAC12EBA2DF100926483 /* DevicePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F8CAC02EBA2DF100926483 /* DevicePreview.swift */; };
+		06F8CAC32EBA459B00926483 /* StreamingInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F8CAC22EBA459B00926483 /* StreamingInspectorView.swift */; };
 		144254312EA9FF7800583CC3 /* OperationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144254302EA9FF7800583CC3 /* OperationContext.swift */; };
 		144254332EAA232300583CC3 /* OperationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144254322EAA232300583CC3 /* OperationViewModel.swift */; };
 		144254342EAA232300583CC3 /* OperationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144254322EAA232300583CC3 /* OperationViewModel.swift */; };
@@ -346,6 +347,7 @@
 		06ADD9CC2EB98B3D0013665B /* OperationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationListView.swift; sourceTree = "<group>"; };
 		06ADD9D12EB98E730013665B /* PatientInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientInputView.swift; sourceTree = "<group>"; };
 		06F8CAC02EBA2DF100926483 /* DevicePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePreview.swift; sourceTree = "<group>"; };
+		06F8CAC22EBA459B00926483 /* StreamingInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingInspectorView.swift; sourceTree = "<group>"; };
 		144254302EA9FF7800583CC3 /* OperationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationContext.swift; sourceTree = "<group>"; };
 		144254322EAA232300583CC3 /* OperationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationViewModel.swift; sourceTree = "<group>"; };
 		144254362EAA9FEB00583CC3 /* OperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationState.swift; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 			children = (
 				0667A5492EB8814100D7BDF3 /* StreamingControlView.swift */,
 				06F8CAC02EBA2DF100926483 /* DevicePreview.swift */,
+				06F8CAC22EBA459B00926483 /* StreamingInspectorView.swift */,
 			);
 			path = StreamingControl;
 			sourceTree = "<group>";
@@ -1795,6 +1798,7 @@
 				C0F97B1E2EA435490063E159 /* CreatePatientCommand.swift in Sources */,
 				14DE51422EB64A2F0027D9A0 /* DetailModelSection.swift in Sources */,
 				25E78B852EB9166900D8CAD2 /* OperationWithPatient.swift in Sources */,
+				06F8CAC32EBA459B00926483 /* StreamingInspectorView.swift in Sources */,
 				25E78B732EB9164200D8CAD2 /* OperationRepository.swift in Sources */,
 				25E78B662EB90D4600D8CAD2 /* OperationStatus.swift in Sources */,
 				25E78B672EB90D4600D8CAD2 /* Operation.swift in Sources */,

--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -66,7 +66,6 @@
 		1494DE712EA72BCE000CD284 /* OperationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE702EA72BCE000CD284 /* OperationDetailView.swift */; };
 		1494DE732EA72BCE000CD284 /* OperationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE702EA72BCE000CD284 /* OperationDetailView.swift */; };
 		1494DE7C2EA73205000CD284 /* DetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE7B2EA73205000CD284 /* DetailHeader.swift */; };
-		1494DE7D2EA73205000CD284 /* DetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE7B2EA73205000CD284 /* DetailHeader.swift */; };
 		1494DE7E2EA73205000CD284 /* DetailHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE7B2EA73205000CD284 /* DetailHeader.swift */; };
 		1494DE802EA7321A000CD284 /* AssetSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE7F2EA7321A000CD284 /* AssetSection.swift */; };
 		1494DE812EA7321A000CD284 /* AssetSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1494DE7F2EA7321A000CD284 /* AssetSection.swift */; };
@@ -1743,7 +1742,6 @@
 				C0F97AAA2EA401160063E159 /* PatientDisplayModel.swift in Sources */,
 				1446FBB12EAE6C23000BCF61 /* RecordButton.swift in Sources */,
 				C0F97B2A2EA439080063E159 /* UpdatePatient.swift in Sources */,
-				1494DE7D2EA73205000CD284 /* DetailHeader.swift in Sources */,
 				1494DE842EA73229000CD284 /* AssetImageCard.swift in Sources */,
 				C0F97AAB2EA401160063E159 /* OperationDisplayModel.swift in Sources */,
 				1494DEA52EA7C851000CD284 /* Date+Extension.swift in Sources */,

--- a/Hippo/Applications/MacApp/HippoMacApp.swift
+++ b/Hippo/Applications/MacApp/HippoMacApp.swift
@@ -13,7 +13,7 @@ struct HippoMacApp: App {
         WindowGroup {
             RootView()
                 .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
-                .frame(minWidth: 600, maxWidth: .infinity, minHeight: 400, maxHeight: .infinity)
+                .frame(minWidth: 1024, maxWidth: .infinity, minHeight: 576, maxHeight: .infinity)
         }
     }
 }

--- a/Hippo/Features/Mac/UI/Home/HomeView.swift
+++ b/Hippo/Features/Mac/UI/Home/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     var mockData = HomeMockDataModel.mockList
-    @Binding var isTodaysSurgery: Bool
+    @State private var isTodaysSurgery: Bool = true
     @State private var selectedPatientID: HomeMockDataModel.ID?
     private var selectedPatient: HomeMockDataModel? { mockData.first { $0.id == selectedPatientID } }
     @State var isPatientInputSheetPresented: Bool = false
@@ -65,6 +65,15 @@ struct HomeView: View {
                     .navigationTitle("Today's Surgery")
             } else {
                 PatientDetailView(patientId: selectedPatientID ?? "")
+            }
+        }
+        .toolbar {
+            if !isTodaysSurgery {
+                Button {
+                    //TODO: 수술 생성 기능 구현
+                } label: {
+                    Label("Create", systemImage: "plus")
+                }
             }
         }
         .sheet(isPresented: $isPatientInputSheetPresented) {

--- a/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
@@ -41,7 +41,10 @@ struct PatientInputView: View {
             }
         }
         .padding()
-
+        
+        Divider()
+            .padding(.horizontal)
+        
         HStack {
             Button("취소") {
                 isPatientInputSheetPresented = false

--- a/Hippo/Features/Mac/UI/RootView.swift
+++ b/Hippo/Features/Mac/UI/RootView.swift
@@ -14,61 +14,27 @@ enum Tabs {
 
 struct RootView: View {
     @State private var selectedTab: Tabs = .Home
-    @State private var isTodaysSurgery: Bool = true
-
+    
     var body: some View {
         NavigationStack {
             // 메인 컨텐츠는 선택된 탭에 따라 전환
             Group {
                 switch selectedTab {
                 case .Home:
-                    HomeView(isTodaysSurgery: $isTodaysSurgery)
+                    HomeView()
                 case .StreamingControl:
                     StreamingControlView()
-                        .navigationTitle(Text("Hippo")) //툴바 버튼 위치 유지를 위해 빈 문자열 타이틀 추가
-                }
-            }
-            .onChange(of: selectedTab) {
-                //StreamingControlView의 디버깅 패널 버튼의 존재가 isTodaysSurgery의 영향을 받지 않기 위해 추가함
-                if selectedTab == .StreamingControl {
-                    isTodaysSurgery = false
-                } else if selectedTab == .Home {
-                    isTodaysSurgery = true
+                        .navigationTitle(Text("Hippo"))  //툴바 영역 허전해서 하나 넣어드림
                 }
             }
             .toolbar {
-
-                ToolbarItemGroup(placement: .primaryAction) { //.primaryAction: 툴바 아이템을 우측정렬
-                    // 상단에 탭 전환용 세그먼트 컨트롤
+                ToolbarItem(placement: .primaryAction) {  //.primaryAction: 툴바 아이템을 우측정렬
+                    // 상단 탭 전환용 세그먼트 컨트롤
                     Picker("Section", selection: $selectedTab) {
                         Text("Patients").tag(Tabs.Home)
                         Text("Camera").tag(Tabs.StreamingControl)
                     }
                     .pickerStyle(.segmented)
-
-                    //툴바 우측 버튼
-                    if !isTodaysSurgery {
-                        Button {
-                            //상황에 따라 버튼 기능이 달라짐
-                            switch selectedTab {
-                            case .Home:
-                                //CASE 1: HomeView에서 환자를 선택하면 수술 생성 버튼
-                                print("홈뷰기능")
-                                //TODO: 환자 생성 기능 구현
-                            case .StreamingControl:
-                                //CASE 2: StreamingControlView에서는 우측 디버깅 창 토글 버튼
-                                print("스트리밍 뷰 기능")
-                                //TODO: 디버깅 패널 토글 기능 구현
-                            }
-                        } label: {
-                            switch selectedTab {
-                            case .Home:
-                                Label("Create", systemImage: "plus")
-                            case .StreamingControl:
-                                Label("Debug", systemImage: "sidebar.right")
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/Hippo/Features/Mac/UI/RootView.swift
+++ b/Hippo/Features/Mac/UI/RootView.swift
@@ -25,7 +25,7 @@ struct RootView: View {
                     HomeView(isTodaysSurgery: $isTodaysSurgery)
                 case .StreamingControl:
                     StreamingControlView()
-                        .navigationTitle(Text("")) //툴바 버튼 위치 유지를 위해 빈 문자열 타이틀 추가
+                        .navigationTitle(Text("Hippo")) //툴바 버튼 위치 유지를 위해 빈 문자열 타이틀 추가
                 }
             }
             .onChange(of: selectedTab) {

--- a/Hippo/Features/Mac/UI/StreamingControl/DevicePreview.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/DevicePreview.swift
@@ -1,0 +1,45 @@
+//
+//  DevicePreview.swift
+//  HippoMac
+//
+//  Created by Hyeok Cho on 11/4/25.
+//
+
+//MARK: DevicePreview.swift
+import SwiftUI
+import AVFoundation
+
+struct DevicePreview: UIViewRepresentable {
+    let preview: AVSampleBufferDisplayLayer
+
+    func makeUIView(context: Context) -> PreviewView {
+        let v = PreviewView()
+        v.videoLayer = preview
+        return v
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {
+        if uiView.videoLayer !== preview {
+            uiView.videoLayer = preview
+        }
+    }
+}
+
+final class PreviewView: UIView {
+    var videoLayer: AVSampleBufferDisplayLayer? {
+        didSet {
+            oldValue?.removeFromSuperlayer()
+            if let l = videoLayer {
+                l.frame = bounds
+                l.videoGravity = .resizeAspect
+                layer.addSublayer(l)
+                setNeedsLayout()
+            }
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        videoLayer?.frame = bounds
+    }
+}

--- a/Hippo/Features/Mac/UI/StreamingControl/DevicePreview.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/DevicePreview.swift
@@ -7,39 +7,84 @@
 
 //MARK: DevicePreview.swift
 import SwiftUI
+import AppKit
 import AVFoundation
 
-struct DevicePreview: UIViewRepresentable {
-    let preview: AVSampleBufferDisplayLayer
+/// A SwiftUI wrapper that hosts a provided CALayer (e.g., AVSampleBufferDisplayLayer)
+/// and keeps it sized to the view's bounds. Use this to display video frames
+/// by passing in your `AVSampleBufferDisplayLayer` from ContentView.
+struct DevicePreview: NSViewRepresentable {
 
-    func makeUIView(context: Context) -> PreviewView {
-        let v = PreviewView()
-        v.videoLayer = preview
-        return v
+    /// The layer to be displayed. Typically an `AVSampleBufferDisplayLayer`.
+    private let preview: CALayer
+
+    /// Designated initializer accepting any CALayer.
+    init(preview: CALayer) {
+        self.preview = preview
     }
 
-    func updateUIView(_ uiView: PreviewView, context: Context) {
-        if uiView.videoLayer !== preview {
-            uiView.videoLayer = preview
-        }
+    /// Convenience initializer specifically for AVSampleBufferDisplayLayer.
+    init(videoLayer: AVSampleBufferDisplayLayer) {
+        self.preview = videoLayer
     }
-}
 
-final class PreviewView: UIView {
-    var videoLayer: AVSampleBufferDisplayLayer? {
-        didSet {
-            oldValue?.removeFromSuperlayer()
-            if let l = videoLayer {
-                l.frame = bounds
-                l.videoGravity = .resizeAspect
-                layer.addSublayer(l)
-                setNeedsLayout()
+    func makeNSView(context: Context) -> SampleBufferPreview {
+        SampleBufferPreview(preview: preview)
+    }
+
+    func updateNSView(_ nsView: SampleBufferPreview, context: Context) {
+        // No-op: sizing is handled in SampleBufferPreview.layout().
+    }
+
+    // MARK: - Backing NSView
+    class SampleBufferPreview: NSView {
+        let preview: CALayer
+
+        init(preview: CALayer) {
+            self.preview = preview
+            super.init(frame: .zero)
+            wantsLayer = true
+
+            // Ensure the host view has a root layer to attach to.
+            if layer == nil {
+                layer = CALayer()
             }
-        }
-    }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        videoLayer?.frame = bounds
+            // Avoid implicit animations when adding/sizing.
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            layer?.addSublayer(preview)
+            preview.frame = bounds
+            preview.contentsGravity = .resizeAspect
+            CATransaction.commit()
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func layout() {
+            super.layout()
+            // Keep the preview layer sized to fill this view.
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            preview.frame = bounds
+            CATransaction.commit()
+        }
+
+        override var isFlipped: Bool { true }
     }
 }
+
+// MARK: - SwiftUI Preview (optional)
+#if DEBUG
+#Preview("DevicePreview Placeholder") {
+    // Show an empty CALayer placeholder in previews.
+    let layer = CALayer()
+    layer.backgroundColor = NSColor.black.withAlphaComponent(0.1).cgColor
+    return DevicePreview(preview: layer)
+        .frame(width: 320, height: 180)
+        .border(Color.gray)
+        .padding()
+}
+#endif

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AVFoundation
 
 enum VideoInputMode {
     case SideBySide
@@ -35,14 +36,16 @@ struct StreamingControlView: View {
     @State private var selectedLeftDeviceId: String = "FaceTime HD Camera"
     @State private var selectedRightDeviceId: String = "UVC Capture A"
 
-    // Monocular
-    @State private var selectedMonoDeviceId: String = "FaceTime HD Camera"
+    // Monoc
+    @State private var selectedDeviceId: String = "FaceTime HD Camera"
     
-    private let cardViewMaxWidth: CGFloat = 600
+    private let videoLayer = AVSampleBufferDisplayLayer()
+    
+    private let pickerCardViewMaxWidth: CGFloat = 600
 
     var body: some View {
         VStack {
-            // Mode
+            // 비디오인풋 선택
             VStack(alignment: .leading) {
                 Text("VideoInputMode")
                 Picker("", selection: $videoInputMode) {
@@ -50,7 +53,7 @@ struct StreamingControlView: View {
                     Text("MonoVideo").tag(VideoInputMode.MonoVideo)
                 }
                 .pickerStyle(.segmented)
-                .frame(maxWidth: cardViewMaxWidth, alignment: .leading)
+                .frame(maxWidth: pickerCardViewMaxWidth, alignment: .leading)
             }
             .padding()
             .background(
@@ -58,7 +61,7 @@ struct StreamingControlView: View {
                     .fill(Color.gray.opacity(0.15))
             )
 
-            // Camera selection
+            // 카메라인풋선택: 3D로 출력하기 위한 영상 vs 2D로 출력하기 위한 영상
             VStack {
                 HStack {
                     Text("CameraInputMode")
@@ -72,47 +75,54 @@ struct StreamingControlView: View {
 
                     }
                 }
-                .frame(maxWidth: cardViewMaxWidth)
+                .frame(maxWidth: pickerCardViewMaxWidth)
 
+                
                 switch videoInputMode {
-                case .SideBySide:
-                    // 두 개의 영상 처리기에서 받아오는 경우 두 개의 피커 생성 또는 단일 입력
+                  
+                case .SideBySide:  //3D로 출력하기 위한 영상(SBS)을 가져오려는 경우
                     switch cameraInputMode {
-                    case .DualInput:
+                       
+                    case .DualInput: //SBS 영상을 두 개의 영상 처리기에서 받아오려는 경우
+                        //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
+                        //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
                         HStack {
                             Picker("Left Camera", selection: $selectedLeftDeviceId) {
                                 ForEach(devices, id: \.self) { device in
                                     Text(device).tag(device)
                                 }
                             }
-
                             Picker("Right Camera", selection: $selectedRightDeviceId) {
                                 ForEach(devices, id: \.self) { device in
                                     Text(device).tag(device)
                                 }
                             }
                         }
-                        .frame(maxWidth: cardViewMaxWidth)
-
-                    case .SingleInput:
+                        .frame(maxWidth: pickerCardViewMaxWidth)
+                        
+                    case .SingleInput: //SBS 영상을 한 개의 영상 처리기에서 받아오려는 경우
+                        //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
+                        //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
                         VStack(alignment: .leading) {
-                            Picker("Camera", selection: $selectedMonoDeviceId) {
+                            Picker("Camera", selection: $selectedDeviceId) {
                                 ForEach(devices, id: \.self) { device in
                                     Text(device).tag(device)
                                 }
                             }
-                            .frame(maxWidth: cardViewMaxWidth)
+                            .frame(maxWidth: pickerCardViewMaxWidth)
                         }
                     }
-
-                case .MonoVideo:
+                    
+                case .MonoVideo: //2D로 출력하기 위한 영상을 가져오려는 경우
                     VStack(alignment: .leading) {
-                        Picker("Camera", selection: $selectedMonoDeviceId) {
+                        //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
+                        //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
+                        Picker("Camera", selection: $selectedDeviceId) {
                             ForEach(devices, id: \.self) { device in
                                 Text(device).tag(device)
                             }
                         }
-                        .frame(maxWidth: cardViewMaxWidth)
+                        .frame(maxWidth: pickerCardViewMaxWidth)
                     }
                 }
                 
@@ -124,6 +134,21 @@ struct StreamingControlView: View {
             )
 
             Spacer()
+            
+            //영상 프리뷰
+            DevicePreview(preview: videoLayer)
+            //                .frame(width: 640, height: 360)
+            //                .background(Color.black.opacity(0.1))
+            
+            //TODO: 스트리밍 시작 버튼
+            Button {
+                //TODO: RTP패킷 전송 기능 연결
+            } label: {
+                HStack {
+                    Image(systemName: "play.fill") //TODO: 커스텀 아이콘으로 변경
+                    Text("Start Streaming")
+                }
+            }
         }
         .padding()
     }

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
@@ -7,12 +7,128 @@
 
 import SwiftUI
 
+enum VideoInputMode {
+    case SideBySide
+    case MonoVideo
+}
+
+enum CameraInputMode {
+    case DualInput
+    case SingleInput
+}
+
 struct StreamingControlView: View {
+    // MARK: - Dummy camera data
+    private let devices: [String] = [
+        "FaceTime HD Camera",
+        "UVC Capture A",
+        "UVC Capture B",
+        "Virtual Cam 1",
+        "Virtual Cam 2"
+    ]
+
+    // MARK: - State
+    @State private var videoInputMode: VideoInputMode = .SideBySide
+    @State private var cameraInputMode: CameraInputMode = .DualInput
+
+    // Stereo
+    @State private var selectedLeftDeviceId: String = "FaceTime HD Camera"
+    @State private var selectedRightDeviceId: String = "UVC Capture A"
+
+    // Monocular
+    @State private var selectedMonoDeviceId: String = "FaceTime HD Camera"
+    
+    private let cardViewMaxWidth: CGFloat = 600
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            // Mode
+            VStack(alignment: .leading) {
+                Text("VideoInputMode")
+                Picker("", selection: $videoInputMode) {
+                    Text("StereoVideo").tag(VideoInputMode.SideBySide)
+                    Text("MonoVideo").tag(VideoInputMode.MonoVideo)
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: cardViewMaxWidth, alignment: .leading)
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.gray.opacity(0.15))
+            )
+
+            // Camera selection
+            VStack {
+                HStack {
+                    Text("CameraInputMode")
+                    Spacer()
+                    if videoInputMode == .SideBySide {
+                        Picker("", selection: $cameraInputMode) {
+                            Text("DualInput").tag(CameraInputMode.DualInput)
+                            Text("SingleInput").tag(CameraInputMode.SingleInput)
+                        }
+                        .pickerStyle(.segmented)
+
+                    }
+                }
+                .frame(maxWidth: cardViewMaxWidth)
+
+                switch videoInputMode {
+                case .SideBySide:
+                    // 두 개의 영상 처리기에서 받아오는 경우 두 개의 피커 생성 또는 단일 입력
+                    switch cameraInputMode {
+                    case .DualInput:
+                        HStack {
+                            Picker("Left Camera", selection: $selectedLeftDeviceId) {
+                                ForEach(devices, id: \.self) { device in
+                                    Text(device).tag(device)
+                                }
+                            }
+
+                            Picker("Right Camera", selection: $selectedRightDeviceId) {
+                                ForEach(devices, id: \.self) { device in
+                                    Text(device).tag(device)
+                                }
+                            }
+                        }
+                        .frame(maxWidth: cardViewMaxWidth)
+
+                    case .SingleInput:
+                        VStack(alignment: .leading) {
+                            Picker("Camera", selection: $selectedMonoDeviceId) {
+                                ForEach(devices, id: \.self) { device in
+                                    Text(device).tag(device)
+                                }
+                            }
+                            .frame(maxWidth: cardViewMaxWidth)
+                        }
+                    }
+
+                case .MonoVideo:
+                    VStack(alignment: .leading) {
+                        Picker("Camera", selection: $selectedMonoDeviceId) {
+                            ForEach(devices, id: \.self) { device in
+                                Text(device).tag(device)
+                            }
+                        }
+                        .frame(maxWidth: cardViewMaxWidth)
+                    }
+                }
+                
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.gray.opacity(0.15))
+            )
+
+            Spacer()
+        }
+        .padding()
     }
 }
 
 #Preview {
-    RootView()
+    StreamingControlView()
 }

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
@@ -29,14 +29,17 @@ struct StreamingControlView: View {
     ]
 
     // MARK: - State
+    @State private var isStreamingInspectorPanelPresented: Bool = false
+
     @State private var videoInputMode: VideoInputMode = .SideBySide
     @State private var cameraInputMode: CameraInputMode = .DualInput
+    
 
-    // Stereo
+    // DualInput용
     @State private var selectedLeftDeviceId: String = "FaceTime HD Camera"
     @State private var selectedRightDeviceId: String = "UVC Capture A"
 
-    // Monoc
+    // SingleInput용
     @State private var selectedDeviceId: String = "FaceTime HD Camera"
     
     private let videoLayer = AVSampleBufferDisplayLayer()
@@ -64,7 +67,7 @@ struct StreamingControlView: View {
                 )
 
                 // 카메라인풋선택: 3D로 출력하기 위한 영상 vs 2D로 출력하기 위한 영상
-                VStack {
+                VStack(alignment: .leading) {
                     HStack {
                         Text("Camera")
                         Spacer()
@@ -144,6 +147,7 @@ struct StreamingControlView: View {
             
             //영상 프리뷰
             Section {
+                //영상 프리뷰 재생 레이어
                 DevicePreview(preview: videoLayer)
                                 .frame(width: 800, height: 240) // 16:9비율 가로픽셀을 600에 가까운 픽셀에 맞춤
                                 .background(Color.black.opacity(0.1))
@@ -167,10 +171,19 @@ struct StreamingControlView: View {
                 }
             }
         }
+        .toolbar {
+            Button {
+                //TODO: 디버깅 패널 토글 기능 구현
+                isStreamingInspectorPanelPresented.toggle()
+            } label: { Label("Debug", systemImage: "sidebar.right") }
+        }
         .padding()
+        .inspector(isPresented: $isStreamingInspectorPanelPresented) {
+            StreamingInspectorView()
+        }
     }
 }
 
 #Preview {
-    StreamingControlView()
+    RootView()
 }

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
@@ -41,69 +41,83 @@ struct StreamingControlView: View {
     
     private let videoLayer = AVSampleBufferDisplayLayer()
     
-    private let pickerCardViewMaxWidth: CGFloat = 600
+    private let pickerCardViewMaxWidth: CGFloat = 800 //DecicePreview(영상 프리뷰)의 가로 길이에 맞춤.
 
     var body: some View {
         VStack {
-            // 비디오인풋 선택
-            VStack(alignment: .leading) {
-                Text("VideoInputMode")
-                Picker("", selection: $videoInputMode) {
-                    Text("StereoVideo").tag(VideoInputMode.SideBySide)
-                    Text("MonoVideo").tag(VideoInputMode.MonoVideo)
-                }
-                .pickerStyle(.segmented)
-                .frame(maxWidth: pickerCardViewMaxWidth, alignment: .leading)
-            }
-            .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color.gray.opacity(0.15))
-            )
-
-            // 카메라인풋선택: 3D로 출력하기 위한 영상 vs 2D로 출력하기 위한 영상
-            VStack {
-                HStack {
-                    Text("CameraInputMode")
-                    Spacer()
-                    if videoInputMode == .SideBySide {
-                        Picker("", selection: $cameraInputMode) {
-                            Text("DualInput").tag(CameraInputMode.DualInput)
-                            Text("SingleInput").tag(CameraInputMode.SingleInput)
-                        }
-                        .pickerStyle(.segmented)
-
+            //인풋 설정
+            Section {
+                // 비디오인풋 선택
+                VStack(alignment: .leading) {
+                    Text("Video")
+                    Picker("", selection: $videoInputMode) {
+                        Text("StereoVideo").tag(VideoInputMode.SideBySide)
+                        Text("MonoVideo").tag(VideoInputMode.MonoVideo)
                     }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: pickerCardViewMaxWidth, alignment: .leading)
                 }
-                .frame(maxWidth: pickerCardViewMaxWidth)
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.gray.opacity(0.15))
+                )
 
+                // 카메라인풋선택: 3D로 출력하기 위한 영상 vs 2D로 출력하기 위한 영상
+                VStack {
+                    HStack {
+                        Text("Camera")
+                        Spacer()
+                        if videoInputMode == .SideBySide {
+                            Picker("", selection: $cameraInputMode) {
+                                Text("Dual").tag(CameraInputMode.DualInput)
+                                Text("Single").tag(CameraInputMode.SingleInput)
+                            }
+                            .pickerStyle(.segmented)
+
+                        }
+                    }
+                    .frame(maxWidth: pickerCardViewMaxWidth)
                 
-                switch videoInputMode {
-                  
-                case .SideBySide:  //3D로 출력하기 위한 영상(SBS)을 가져오려는 경우
-                    switch cameraInputMode {
-                       
-                    case .DualInput: //SBS 영상을 두 개의 영상 처리기에서 받아오려는 경우
-                        //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
-                        //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
-                        HStack {
-                            Picker("Left Camera", selection: $selectedLeftDeviceId) {
-                                ForEach(devices, id: \.self) { device in
-                                    Text(device).tag(device)
+                    switch videoInputMode {
+                      
+                    case .SideBySide:  //3D로 출력하기 위한 영상(SBS)을 가져오려는 경우
+                        switch cameraInputMode {
+                           
+                        case .DualInput: //SBS 영상을 두 개의 영상 처리기에서 받아오려는 경우
+                            //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
+                            //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
+                            HStack {
+                                Picker("Left Camera", selection: $selectedLeftDeviceId) {
+                                    ForEach(devices, id: \.self) { device in
+                                        Text(device).tag(device)
+                                    }
+                                }
+                                Picker("Right Camera", selection: $selectedRightDeviceId) {
+                                    ForEach(devices, id: \.self) { device in
+                                        Text(device).tag(device)
+                                    }
                                 }
                             }
-                            Picker("Right Camera", selection: $selectedRightDeviceId) {
-                                ForEach(devices, id: \.self) { device in
-                                    Text(device).tag(device)
+                            .frame(maxWidth: pickerCardViewMaxWidth)
+                            
+                        case .SingleInput: //SBS 영상을 한 개의 영상 처리기에서 받아오려는 경우
+                            //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
+                            //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
+                            VStack(alignment: .leading) {
+                                Picker("Camera", selection: $selectedDeviceId) {
+                                    ForEach(devices, id: \.self) { device in
+                                        Text(device).tag(device)
+                                    }
                                 }
+                                .frame(maxWidth: pickerCardViewMaxWidth)
                             }
                         }
-                        .frame(maxWidth: pickerCardViewMaxWidth)
                         
-                    case .SingleInput: //SBS 영상을 한 개의 영상 처리기에서 받아오려는 경우
-                        //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
-                        //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
+                    case .MonoVideo: //2D로 출력하기 위한 영상을 가져오려는 경우
                         VStack(alignment: .leading) {
+                            //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
+                            //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
                             Picker("Camera", selection: $selectedDeviceId) {
                                 ForEach(devices, id: \.self) { device in
                                     Text(device).tag(device)
@@ -112,37 +126,40 @@ struct StreamingControlView: View {
                             .frame(maxWidth: pickerCardViewMaxWidth)
                         }
                     }
-                    
-                case .MonoVideo: //2D로 출력하기 위한 영상을 가져오려는 경우
-                    VStack(alignment: .leading) {
-                        //TODO: 피커 내부 selectedDeviceId를 실제 데이터로 교체
-                        //TODO: ForEach 내부 device는 실제 [AVCaptureDevice]로 교체
-                        Picker("Camera", selection: $selectedDeviceId) {
-                            ForEach(devices, id: \.self) { device in
-                                Text(device).tag(device)
-                            }
-                        }
-                        .frame(maxWidth: pickerCardViewMaxWidth)
-                    }
                 }
-                
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.gray.opacity(0.15))
+                )
+            } header: {
+                HStack {
+                    Text("InputModes")
+                    Spacer()
+                }
+                .frame(maxWidth: pickerCardViewMaxWidth, alignment: .leading)
             }
-            .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color.gray.opacity(0.15))
-            )
-
+            
             Spacer()
             
             //영상 프리뷰
-            DevicePreview(preview: videoLayer)
-            //                .frame(width: 640, height: 360)
-            //                .background(Color.black.opacity(0.1))
+            Section {
+                DevicePreview(preview: videoLayer)
+                                .frame(width: 800, height: 240) // 16:9비율 가로픽셀을 600에 가까운 픽셀에 맞춤
+                                .background(Color.black.opacity(0.1))
+            } header: {
+                HStack {
+                    Text("Preview")
+                    Spacer()
+                }
+                .frame(maxWidth: pickerCardViewMaxWidth, alignment: .leading)
+            }
             
-            //TODO: 스트리밍 시작 버튼
+            Spacer()
+            
+            //스트리밍 시작 버튼
             Button {
-                //TODO: RTP패킷 전송 기능 연결
+                //TODO: 네트워크 RTP패킷 전송 기능 연결
             } label: {
                 HStack {
                     Image(systemName: "play.fill") //TODO: 커스텀 아이콘으로 변경

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingInspectorView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingInspectorView.swift
@@ -1,0 +1,40 @@
+//
+//  StreamingMonitorPanel.swift
+//  HippoMac
+//
+//  Created by Hyeok Cho on 11/4/25.
+//
+
+import SwiftUI
+
+struct StreamingInspectorView: View {
+    var body: some View {
+        ScrollView {
+            //Controls
+            Section {
+                
+            } header: {
+                HStack {
+                    Text("Controls")
+                    Spacer()
+                }
+                
+            }
+            
+            //Statistics
+            Section {
+                
+            } header: {
+                HStack {
+                    Text("Statistics")
+                    Spacer()
+                }
+            }
+        }
+            .padding()
+    }
+}
+
+#Preview {
+    StreamingInspectorView()
+}

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingInspectorView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingInspectorView.swift
@@ -8,30 +8,204 @@
 import SwiftUI
 
 struct StreamingInspectorView: View {
+    //MARK: 더미 데이터
+    enum NormalizationPolicy: String, CaseIterable, Identifiable {
+        case cropScale = "Crop & Scale Down"
+        case scaleDown = "Scale Down Only"
+        case letterbox = "Letterbox Fit"
+        case fitInside = "Fit Inside Frame"
+        case stretchFill = "Stretch to Fill"
+        case passthrough = "Passthrough (No Normalization)"
+
+        var id: String { self.rawValue }
+    }
+
+    @State private var normalizationPolicy: NormalizationPolicy = .cropScale
+    @State private var targetBitrate: Double = 6
+    @State private var isControlsCollapsed: Bool = false
+    @State private var isStatisticsCollapsed: Bool = false
+
+    private let sliderMin = 5.0
+    private let sliderMax = 20.0
+
     var body: some View {
         ScrollView {
             //Controls
             Section {
-                
+                if !isControlsCollapsed {
+                    VStack {
+                        //Normalization
+
+                        HStack {
+                            Text("Normalization Policy")
+                            Spacer()
+                        }
+                        Picker("", selection: $normalizationPolicy) {  //TODO: 실제 방식으로 교체
+                            ForEach(NormalizationPolicy.allCases) { policy in
+                                Text(policy.rawValue).tag(policy)
+                            }
+                        }
+                        .padding(.bottom)
+
+                        //TargetBitrate
+                        HStack {
+                            Text("Target Bitrate: \(Int(targetBitrate)) Mbps")
+                            Spacer()
+                        }
+                        //Slider
+                        HStack {
+                            Text("\(Int(sliderMin))")  //최소값 인디케이터
+                            Slider(
+                                value: $targetBitrate,
+                                in: sliderMin...sliderMax
+                            )
+                            Text("\(Int(sliderMax))")  //최대값 인디케이터
+                        }
+                    }
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color.gray.opacity(0.15))
+                    )
+                }
             } header: {
                 HStack {
                     Text("Controls")
                     Spacer()
+                    Button {  //TODO: 컴포넌트화: Statistics섹션에서도 동일한 기능 사용됨.
+                        isControlsCollapsed.toggle()
+                    } label: {
+                        if !isControlsCollapsed {
+                            Image(systemName: "chevron.down")
+                        } else {
+                            Image(systemName: "chevron.right")
+                        }
+                    }
                 }
-                
+
             }
-            
+
+            Spacer()
+
             //Statistics
             Section {
-                
+                if !isStatisticsCollapsed {
+                    VStack {
+                        //CaptureRate
+                        Section {
+                            HStack {
+                                Text("Left")
+                                Spacer()
+                                Text("fps")
+                                Spacer()
+                                Text("Right")
+                                Spacer()
+                                Text("fps")
+                            }
+                            .padding(.bottom)
+                        } header: {
+                            HStack {
+                                Text("CaptureRate")
+                                Spacer()
+                            }
+                            Spacer()
+                        }
+
+                        //SynkRate
+                        Section {
+                            HStack {
+                                Text("Pairs")
+                                Spacer()
+                                Text("fps")
+                                Spacer()
+                                Text("Drops")
+                                Spacer()
+                                Text("fps")
+                            }
+                            .padding(.bottom)
+                        } header: {
+                            HStack {
+                                Text("SyncRate")
+                                Spacer()
+                            }
+                            Spacer()
+                        }
+
+                        //Network
+                        Section {
+                            HStack {
+                                Text("Bitrate")
+                                Spacer()
+                                Text("mbps")
+                                Spacer()
+                                Text("encode")
+                                Spacer()
+                                Text("fps")
+                            }
+                            .padding(.bottom)
+                        } header: {
+                            HStack {
+                                Text("Network")
+                                Spacer()
+                            }
+                            Spacer()
+                        }
+
+                        //Ratencies
+                        Section {
+                            VStack {
+                                HStack {
+                                    Text("Capture")
+                                    Spacer()
+                                    Text("ms")
+                                    Spacer()
+                                    Text("Compose")
+                                    Spacer()
+                                    Text("ms")
+                                }
+                                HStack {
+                                    Text("Encode")
+                                    Spacer()
+                                    Text("ms")
+                                    Spacer()
+                                    Text("Right")
+                                    Spacer()
+                                    Text("E2E")
+                                }
+                            }
+
+                            .padding(.bottom)
+                        } header: {
+                            HStack {
+                                Text("Ratencies")
+                                Spacer()
+                            }
+                            Spacer()
+                        }
+                    }
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color.gray.opacity(0.15))
+                    )
+                }
             } header: {
                 HStack {
                     Text("Statistics")
                     Spacer()
+                    Button {  //TODO: 컴포넌트화: Statistics섹션에서도 동일한 기능 사용됨
+                        isStatisticsCollapsed.toggle()
+                    } label: {
+                        if !isStatisticsCollapsed {
+                            Image(systemName: "chevron.down")
+                        } else {
+                            Image(systemName: "chevron.right")
+                        }
+                    }
                 }
             }
         }
-            .padding()
+        .padding()
     }
 }
 

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingInspectorView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingInspectorView.swift
@@ -1,5 +1,5 @@
 //
-//  StreamingMonitorPanel.swift
+//  StreamingInspectorView.swift
 //  HippoMac
 //
 //  Created by Hyeok Cho on 11/4/25.
@@ -151,7 +151,7 @@ struct StreamingInspectorView: View {
                             Spacer()
                         }
 
-                        //Ratencies
+                        //Latencies
                         Section {
                             VStack {
                                 HStack {
@@ -177,7 +177,7 @@ struct StreamingInspectorView: View {
                             .padding(.bottom)
                         } header: {
                             HStack {
-                                Text("Ratencies")
+                                Text("Latencies")
                                 Spacer()
                             }
                             Spacer()


### PR DESCRIPTION
## 📕 Issue Number

Close #79 


## 📙 작업 내역

> StreamingControlView와 StreamingInspectorView(우측 패널을 인스펙터라고 하덥니다.) 최소 UI 구현을 완료하였습니다.
영상 프리뷰를 재생을 위해 DevicePreview를 추가하였습니다.

- 기존 디자인의 용어를 더 명확히 수정하고,
mode -> videoInputMode
camera -> cameraInputMode
우리의 testcase에 더 적합한 방식의 UI분기로 수정하였습니다.
FullSBS, HalfSBS -> stereoVideo로 통합 후, CameraInputMode의 DualInputMode(이게 FullSBS), SingleInputMode(이게 HalfSBS)로 치환

- 툴 바 우측 버튼 선언 위치를 RootView에서 HomeView와 StreamingControlView로 각각 이전하였습니다. RootView에 있던 isTodaysSurgery 상태변수도 HomeView로 이전합니다.

- 컴포넌트화 가능한 코드들이 있습니다. 추후 리팩터링 하겠습니다.
- 
- [x] 작업 내역 작성


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

- 스크린 샷

https://github.com/user-attachments/assets/5d5adb6e-d2ed-4275-8ef7-8b350f1e9e33





## 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 툴 바 우측 버튼 선언 위치를 RootView에서 HomeView와 StreamingControlView로 각각 이전한 이유는 버튼 기능의 분기 처리가 깔끔해지기 때문도 있지만, 기존 방식으로 선언하는 경우 피커가 강제로 최소화 되는 문제도 존재하였기 때문입니다.
기존
<img width="1220" height="740" alt="스크린샷 2025-11-05 00 16 26" src="https://github.com/user-attachments/assets/03584699-d528-4223-b2be-90701e5643f3" />
변경
<img width="1220" height="740" alt="스크린샷 2025-11-05 00 16 54" src="https://github.com/user-attachments/assets/ea04c71b-9ea3-4b08-82d0-e7dcd9ebb6ec" />


<br><br>
