### PR TITLE
[Mac] state 객체 분리 및 viewmodel 추가

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -12,9 +12,9 @@
 		0667A54C2EB8833D00D7BDF3 /* PatientDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667A54B2EB8833D00D7BDF3 /* PatientDetailView.swift */; };
 		0667A54E2EB8961C00D7BDF3 /* TodaysSurgeryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667A54D2EB8961C00D7BDF3 /* TodaysSurgeryView.swift */; };
 		0667A5512EB8A34300D7BDF3 /* HomeMockDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667A5502EB8A33400D7BDF3 /* HomeMockDataModel.swift */; };
-		06F8CA722EB9D49400926483 /* OperationInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F8CA712EB9D49400926483 /* OperationInputView.swift */; };
 		06ADD9CD2EB98B3D0013665B /* OperationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ADD9CC2EB98B3D0013665B /* OperationListView.swift */; };
 		06ADD9D22EB98E730013665B /* PatientInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06ADD9D12EB98E730013665B /* PatientInputView.swift */; };
+		06F8CA722EB9D49400926483 /* OperationInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F8CA712EB9D49400926483 /* OperationInputView.swift */; };
 		06F8CAC12EBA2DF100926483 /* DevicePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F8CAC02EBA2DF100926483 /* DevicePreview.swift */; };
 		06F8CAC32EBA459B00926483 /* StreamingInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F8CAC22EBA459B00926483 /* StreamingInspectorView.swift */; };
 		144254312EA9FF7800583CC3 /* OperationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144254302EA9FF7800583CC3 /* OperationContext.swift */; };
@@ -127,6 +127,11 @@
 		14DE51542EB771420027D9A0 /* HIPPO.icon in Resources */ = {isa = PBXBuildFile; fileRef = 14DE51512EB771420027D9A0 /* HIPPO.icon */; };
 		14DE51562EB779960027D9A0 /* EmptyPatientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DE51552EB7798B0027D9A0 /* EmptyPatientView.swift */; };
 		14F6B0342EAAC73F003F28EB /* ImmersiveSurgeryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F6B0332EAAC73F003F28EB /* ImmersiveSurgeryView.swift */; };
+		2581FCE52EBBC6870059678D /* OperationInputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2581FCE42EBBC6870059678D /* OperationInputState.swift */; };
+		2581FCE92EBBC6FA0059678D /* MacNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2581FCE62EBBC6FA0059678D /* MacNavigationState.swift */; };
+		2581FCEA2EBBC6FA0059678D /* MacRootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2581FCE72EBBC6FA0059678D /* MacRootViewModel.swift */; };
+		2581FCED2EBBC76D0059678D /* PatientDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2581FCEB2EBBC76D0059678D /* PatientDetailViewModel.swift */; };
+		2581FCEE2EBBC76D0059678D /* PatientInputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2581FCEC2EBBC76D0059678D /* PatientInputState.swift */; };
 		25E78B602EB90D4600D8CAD2 /* OperationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E78B5D2EB90D4600D8CAD2 /* OperationStatus.swift */; };
 		25E78B612EB90D4600D8CAD2 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E78B542EB90D4600D8CAD2 /* Operation.swift */; };
 		25E78B622EB90D4600D8CAD2 /* OperationAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E78B552EB90D4600D8CAD2 /* OperationAsset.swift */; };
@@ -344,9 +349,9 @@
 		0667A54B2EB8833D00D7BDF3 /* PatientDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientDetailView.swift; sourceTree = "<group>"; };
 		0667A54D2EB8961C00D7BDF3 /* TodaysSurgeryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaysSurgeryView.swift; sourceTree = "<group>"; };
 		0667A5502EB8A33400D7BDF3 /* HomeMockDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMockDataModel.swift; sourceTree = "<group>"; };
-		06F8CA712EB9D49400926483 /* OperationInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationInputView.swift; sourceTree = "<group>"; };
 		06ADD9CC2EB98B3D0013665B /* OperationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationListView.swift; sourceTree = "<group>"; };
 		06ADD9D12EB98E730013665B /* PatientInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientInputView.swift; sourceTree = "<group>"; };
+		06F8CA712EB9D49400926483 /* OperationInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationInputView.swift; sourceTree = "<group>"; };
 		06F8CAC02EBA2DF100926483 /* DevicePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePreview.swift; sourceTree = "<group>"; };
 		06F8CAC22EBA459B00926483 /* StreamingInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingInspectorView.swift; sourceTree = "<group>"; };
 		144254302EA9FF7800583CC3 /* OperationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationContext.swift; sourceTree = "<group>"; };
@@ -411,6 +416,11 @@
 		14DE51512EB771420027D9A0 /* HIPPO.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = HIPPO.icon; sourceTree = "<group>"; };
 		14DE51552EB7798B0027D9A0 /* EmptyPatientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPatientView.swift; sourceTree = "<group>"; };
 		14F6B0332EAAC73F003F28EB /* ImmersiveSurgeryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmersiveSurgeryView.swift; sourceTree = "<group>"; };
+		2581FCE42EBBC6870059678D /* OperationInputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationInputState.swift; sourceTree = "<group>"; };
+		2581FCE62EBBC6FA0059678D /* MacNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacNavigationState.swift; sourceTree = "<group>"; };
+		2581FCE72EBBC6FA0059678D /* MacRootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacRootViewModel.swift; sourceTree = "<group>"; };
+		2581FCEB2EBBC76D0059678D /* PatientDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientDetailViewModel.swift; sourceTree = "<group>"; };
+		2581FCEC2EBBC76D0059678D /* PatientInputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientInputState.swift; sourceTree = "<group>"; };
 		25E78B542EB90D4600D8CAD2 /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
 		25E78B552EB90D4600D8CAD2 /* OperationAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationAsset.swift; sourceTree = "<group>"; };
 		25E78B562EB90D4600D8CAD2 /* OperationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationRecording.swift; sourceTree = "<group>"; };
@@ -544,6 +554,8 @@
 		0617C8FE2EB8BBCB003B26E8 /* Patient */ = {
 			isa = PBXGroup;
 			children = (
+				2581FCEB2EBBC76D0059678D /* PatientDetailViewModel.swift */,
+				2581FCEC2EBBC76D0059678D /* PatientInputState.swift */,
 				0667A54B2EB8833D00D7BDF3 /* PatientDetailView.swift */,
 				06ADD9D12EB98E730013665B /* PatientInputView.swift */,
 			);
@@ -857,6 +869,15 @@
 				14DE51492EB740710027D9A0 /* EmptyTodaySurgeryView.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		2581FCE82EBBC6FA0059678D /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				2581FCE62EBBC6FA0059678D /* MacNavigationState.swift */,
+				2581FCE72EBBC6FA0059678D /* MacRootViewModel.swift */,
+			);
+			path = Root;
 			sourceTree = "<group>";
 		};
 		25E78B522EB90D4600D8CAD2 /* Commands */ = {
@@ -1185,13 +1206,14 @@
 		C050AA182EA80E6200352314 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				2581FCE82EBBC6FA0059678D /* Root */,
+				2581FCE42EBBC6870059678D /* OperationInputState.swift */,
 				06ADD9CE2EB98DA40013665B /* OperationList */,
 				0617C8FE2EB8BBCB003B26E8 /* Patient */,
 				0617C8FD2EB8BBC0003B26E8 /* TodaysSurgery */,
 				0617C8FC2EB8BB9F003B26E8 /* StreamingControl */,
 				0667A54F2EB8A2F900D7BDF3 /* Home */,
 				C02FFA532E9FFF6F00F16742 /* RootView.swift */,
-				C04678462EA00C2700D160DA /* Patients */,
 				06F8CA712EB9D49400926483 /* OperationInputView.swift */,
 				C04678462EA00C2700D160DA /* Patients_Legacy */,
 			);
@@ -1740,6 +1762,8 @@
 				144254372EAA9FF000583CC3 /* OperationState.swift in Sources */,
 				C0F97AC92EA41D4B0063E159 /* SDOperationAsset.swift in Sources */,
 				144254692EAAC61F00583CC3 /* WindowIDs.swift in Sources */,
+				2581FCE92EBBC6FA0059678D /* MacNavigationState.swift in Sources */,
+				2581FCEA2EBBC6FA0059678D /* MacRootViewModel.swift in Sources */,
 				C0F97ACA2EA41D4B0063E159 /* PatientLocalDataSourceLegacyJSON.swift in Sources */,
 				C0F97ADB2EA420E10063E159 /* DataDependencies.swift in Sources */,
 				25E78BB42EB92A2E00D8CAD2 /* UpdateOperationCommand.swift in Sources */,
@@ -1748,6 +1772,8 @@
 				C0F97AAA2EA401160063E159 /* PatientDisplayModel.swift in Sources */,
 				1446FBB12EAE6C23000BCF61 /* RecordButton.swift in Sources */,
 				C0F97B2A2EA439080063E159 /* UpdatePatient.swift in Sources */,
+				2581FCED2EBBC76D0059678D /* PatientDetailViewModel.swift in Sources */,
+				2581FCEE2EBBC76D0059678D /* PatientInputState.swift in Sources */,
 				1494DE842EA73229000CD284 /* AssetImageCard.swift in Sources */,
 				C0F97AAB2EA401160063E159 /* OperationDisplayModel.swift in Sources */,
 				1494DEA52EA7C851000CD284 /* Date+Extension.swift in Sources */,
@@ -1804,6 +1830,7 @@
 				25E78B662EB90D4600D8CAD2 /* OperationStatus.swift in Sources */,
 				25E78B672EB90D4600D8CAD2 /* Operation.swift in Sources */,
 				25E78B682EB90D4600D8CAD2 /* OperationAsset.swift in Sources */,
+				2581FCE52EBBC6870059678D /* OperationInputState.swift in Sources */,
 				25E78B692EB90D4600D8CAD2 /* OperationRecording.swift in Sources */,
 				25E78B6A2EB90D4600D8CAD2 /* OperationError.swift in Sources */,
 				25E78B6B2EB90D4600D8CAD2 /* OperationAssetExtension.swift in Sources */,

--- a/Hippo/Features/Mac/UI/Home/HomeView.swift
+++ b/Hippo/Features/Mac/UI/Home/HomeView.swift
@@ -8,13 +8,17 @@
 import SwiftUI
 
 struct HomeView: View {
+    // ViewModel 초기화
+    @State private var rootVM = MacRootViewModel()
+
+    // Mock 데이터 (UI 개발용 - 나중에 rootVM.homeViewModel.state.items로 교체)
     var mockData = HomeMockDataModel.mockList
     @State private var isTodaysSurgery: Bool = true
     @State private var selectedPatientID: HomeMockDataModel.ID?
-    
+
     @State var isPatientInputSheetPresented: Bool = false
     @State var isOperationInputSheetPresented: Bool = false
-    
+
     private var selectedPatient: HomeMockDataModel? { mockData.first { $0.id == selectedPatientID } }
     
     var body: some View {
@@ -64,10 +68,13 @@ struct HomeView: View {
             }
         } detail: {
             if isTodaysSurgery {
-                TodaysSurgeryView()
+                TodaysSurgeryView(viewModel: rootVM.homeViewModel)
                     .navigationTitle("Today's Surgery")
             } else {
-                PatientDetailView(patientId: selectedPatientID ?? "")
+                PatientDetailView(
+                    viewModel: PatientDetailViewModel(rootVM: rootVM),
+                    patientId: selectedPatientID ?? ""
+                )
             }
         }
         .toolbar {
@@ -81,10 +88,35 @@ struct HomeView: View {
             }
         }
         .sheet(isPresented: $isPatientInputSheetPresented) {
-            PatientInputView(isPatientInputSheetPresented: $isPatientInputSheetPresented)
+            PatientInputView(
+                isPatientInputSheetPresented: $isPatientInputSheetPresented,
+                state: $rootVM.patientInputState,
+                mode: rootVM.navigationState.patientInputMode,
+                onSave: {
+                    Task {
+                        if rootVM.navigationState.patientInputMode == .create {
+                            await rootVM.createPatient()
+                        } else {
+                            await rootVM.updatePatient()
+                        }
+                    }
+                }
+            )
         }
         .sheet(isPresented: $isOperationInputSheetPresented) {
-            OperationInputView(isOperationInputSheetPresented: $isOperationInputSheetPresented)
+            OperationInputView(
+                isOperationInputSheetPresented: $isOperationInputSheetPresented,
+                state: $rootVM.operationInputState,
+                onSave: {
+                    Task {
+                        await rootVM.createOperation()
+                    }
+                }
+            )
+        }
+        .task {
+            // 데이터 로드
+            await rootVM.load()
         }
     }
 }

--- a/Hippo/Features/Mac/UI/OperationInputState.swift
+++ b/Hippo/Features/Mac/UI/OperationInputState.swift
@@ -1,0 +1,91 @@
+//
+//  OperationInputState.swift
+//  HippoMac
+//
+//  Created by Claude on 11/6/25.
+//
+
+import Foundation
+
+/// 수술 입력 폼의 상태를 관리하는 구조체
+public struct OperationInputState {
+    /// 수술 제목
+    public var title: String = ""
+
+    /// 진단(병명)
+    public var diagnosis: String = ""
+
+    /// 집도의
+    public var surgeon: String = ""
+
+    /// 수술 부위
+    public var surgicalSite: String = ""
+
+    /// 수술 날짜
+    public var operationDate: Date = Date()
+
+    /// 수술 상세
+    public var details: String = ""
+
+    /// 3D 모델 에셋 목록
+    public var assets: [OperationAssetDisplayModel] = []
+
+    /// 파일 피커 표시 여부
+    public var isShowingFilePicker: Bool = false
+
+    /// 에러 메시지
+    public var errorMessage: String?
+
+    public init() {}
+
+    /// 수술 정보로 초기화 (수정 모드)
+    public init(from operation: OperationDisplayModel) {
+        self.title = operation.title
+        self.diagnosis = operation.diagnosis
+        self.surgeon = operation.surgeon
+        self.surgicalSite = operation.surgicalSite
+        self.operationDate = operation.date
+        self.details = operation.details
+        self.assets = operation.assets
+    }
+
+    /// 폼 초기화
+    public mutating func reset() {
+        title = ""
+        diagnosis = ""
+        surgeon = ""
+        surgicalSite = ""
+        operationDate = Date()
+        details = ""
+        assets = []
+        isShowingFilePicker = false
+        errorMessage = nil
+    }
+
+    /// 3D 모델 파일 추가
+    public mutating func addAsset(fileURL: URL, fileName: String) {
+        let asset = OperationAssetDisplayModel(
+            id: UUID().uuidString,
+            fileName: fileName,
+            createdAt: Date(),
+            fileURL: fileURL
+        )
+        assets.append(asset)
+    }
+
+    /// 3D 모델 파일 삭제
+    public mutating func removeAsset(at index: Int) {
+        guard assets.indices.contains(index) else { return }
+        assets.remove(at: index)
+    }
+
+    /// 특정 에셋 삭제
+    public mutating func removeAsset(id: String) {
+        assets.removeAll { $0.id == id }
+    }
+
+    /// 폼 유효성 검증
+    public var isValid: Bool {
+        !title.isEmpty && !diagnosis.isEmpty && !surgeon.isEmpty && !surgicalSite.isEmpty
+    }
+}

--- a/Hippo/Features/Mac/UI/OperationInputView.swift
+++ b/Hippo/Features/Mac/UI/OperationInputView.swift
@@ -9,6 +9,11 @@ import SwiftUI
 
 struct OperationInputView: View {
     @Binding var isOperationInputSheetPresented: Bool
+
+    // ViewModel State 바인딩 (HomeView의 rootVM에서 전달받음)
+    @Binding var state: OperationInputState
+    let onSave: () async -> Void
+
     @State private var operationDate = Date()
 
     var body: some View {
@@ -66,5 +71,10 @@ struct OperationInputView: View {
 }
 
 #Preview {
-    RootView()
+    @Previewable @State var state = OperationInputState()
+    OperationInputView(
+        isOperationInputSheetPresented: .constant(true),
+        state: $state,
+        onSave: { }
+    )
 }

--- a/Hippo/Features/Mac/UI/OperationList/OperationListView.swift
+++ b/Hippo/Features/Mac/UI/OperationList/OperationListView.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 
 struct OperationListView: View {
+    // PatientDetailView에서 전달받을 데이터
+    let operations: [OperationDisplayModel]
+    let onDelete: (String) async -> Void
+
     var body: some View {
         Text("입력된 수술이 없습니다.")
         //TODO: 리스트 뷰 or 스크롤 뷰 선택
@@ -16,5 +20,8 @@ struct OperationListView: View {
 }
 
 #Preview {
-    OperationListView()
+    OperationListView(
+        operations: [],
+        onDelete: { _ in }
+    )
 }

--- a/Hippo/Features/Mac/UI/Patient/PatientDetailView.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientDetailView.swift
@@ -8,18 +8,32 @@
 import SwiftUI
 
 struct PatientDetailView: View {
+    // ViewModel 초기화 (HomeView에서 rootVM 전달받음)
+    let viewModel: PatientDetailViewModel
+
+    // Mock 데이터 (UI 개발용)
     var mockData = HomeMockDataModel.mockList
-    
     let patientId: HomeMockDataModel.ID
     private var selectedPatient: HomeMockDataModel? { mockData.first { $0.id == patientId } }
     
     var body: some View {
-        OperationListView()
-            .navigationTitle(selectedPatient.map { "\($0.name) \($0.gender) \($0.age)세" } ?? "환자 상세 정보")
-            .navigationSubtitle(selectedPatient?.patientNumber ?? "환자 번호")
+        OperationListView(
+            operations: viewModel.operations,
+            onDelete: { operationID in
+                Task {
+                    await viewModel.deleteOperation(operationID)
+                }
+            }
+        )
+        .navigationTitle(selectedPatient.map { "\($0.name) \($0.gender) \($0.age)세" } ?? "환자 상세 정보")
+        .navigationSubtitle(selectedPatient?.patientNumber ?? "환자 번호")
     }
 }
 
 #Preview {
-    RootView()
+    let rootVM = MacRootViewModel()
+    PatientDetailView(
+        viewModel: PatientDetailViewModel(rootVM: rootVM),
+        patientId: ""
+    )
 }

--- a/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
@@ -1,0 +1,46 @@
+//
+//  PatientDetailViewModel.swift
+//  HippoMac
+//
+//  Created by Claude on 11/6/25.
+//
+
+import Foundation
+import Observation
+
+/// 환자 상세 화면의 ViewModel
+/// MacRootViewModel의 데이터를 재사용하여 환자 정보 제공
+@MainActor
+@Observable
+public final class PatientDetailViewModel {
+    private let rootVM: MacRootViewModel
+
+    public init(rootVM: MacRootViewModel) {
+        self.rootVM = rootVM
+    }
+
+    // MARK: - Computed Properties (rootVM 재사용)
+
+    /// 현재 선택된 환자
+    public var patient: PatientDisplayModel? {
+        rootVM.selectedPatient
+    }
+
+    /// 선택된 환자의 수술 목록
+    public var operations: [OperationDisplayModel] {
+        rootVM.selectedPatientOperations
+    }
+
+    // MARK: - Actions (rootVM 위임)
+
+    /// 환자 삭제
+    public func deletePatient() async {
+        guard let patientID = patient?.id else { return }
+        await rootVM.deletePatient(patientID)
+    }
+
+    /// 수술 삭제
+    public func deleteOperation(_ operationID: String) async {
+        await rootVM.deleteOperation(operationID: operationID)
+    }
+}

--- a/Hippo/Features/Mac/UI/Patient/PatientInputState.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientInputState.swift
@@ -1,0 +1,58 @@
+//
+//  PatientInputState.swift
+//  HippoMac
+//
+//  Created by Claude on 11/6/25.
+//
+
+import Foundation
+
+/// 환자 입력 폼의 상태를 관리하는 구조체
+public struct PatientInputState {
+    /// 환자 등록 번호
+    public var patientNumber: String = ""
+
+    /// 이름
+    public var name: String = ""
+
+    /// 성별
+    public var selectedGender: Gender = .male
+
+    /// 생년월일
+    public var birthDate: Date = Date()
+
+    /// 에러 메시지
+    public var errorMessage: String?
+
+    public init() {}
+
+    /// 환자 정보로 초기화 (수정 모드)
+    public init(from patient: PatientDisplayModel) {
+        self.patientNumber = patient.patientNumber
+        self.name = patient.name
+        self.selectedGender = patient.gender
+        self.birthDate = patient.birthDate
+    }
+
+    /// 폼 초기화
+    public mutating func reset() {
+        patientNumber = ""
+        name = ""
+        selectedGender = .male
+        birthDate = Date()
+        errorMessage = nil
+    }
+
+    /// 나이 계산
+    public var age: Int {
+        let calendar = Calendar.current
+        let now = Date()
+        let yearDiff = calendar.dateComponents([.year], from: birthDate, to: now).year ?? 0
+        return max(yearDiff, 0)
+    }
+
+    /// 폼 유효성 검증
+    public var isValid: Bool {
+        !patientNumber.isEmpty && !name.isEmpty
+    }
+}

--- a/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
@@ -9,6 +9,12 @@ import SwiftUI
 
 struct PatientInputView: View {
     @Binding var isPatientInputSheetPresented: Bool
+
+    // ViewModel State 바인딩 (HomeView의 rootVM에서 전달받음)
+    @Binding var state: PatientInputState
+    let mode: PatientInputMode
+    let onSave: () async -> Void
+
     @State private var birthDate = Date()
 
     private var age: Int {

--- a/Hippo/Features/Mac/UI/Root/MacNavigationState.swift
+++ b/Hippo/Features/Mac/UI/Root/MacNavigationState.swift
@@ -1,0 +1,80 @@
+//
+//  MacNavigationState.swift
+//  HippoMac
+//
+//  Created by Claude on 11/6/25.
+//
+
+import Foundation
+
+/// Mac 앱의 네비게이션 상태를 관리하는 구조체
+public struct MacNavigationState {
+    /// 현재 선택된 환자 ID
+    public var selectedPatientID: String?
+
+    /// 오늘의 수술 화면 표시 여부
+    public var isTodaysSurgerySelected: Bool = true
+
+    /// 환자 입력 시트 표시 여부
+    public var isPresentingPatientInput: Bool = false
+
+    /// 수술 입력 시트 표시 여부
+    public var isPresentingOperationInput: Bool = false
+
+    /// 환자 입력 모드 (생성/수정)
+    public var patientInputMode: PatientInputMode = .create
+
+    /// 수정할 환자 정보 (수정 모드일 때)
+    public var patientToEdit: PatientDisplayModel?
+
+    public init() {}
+
+    /// 오늘의 수술 화면으로 전환
+    public mutating func selectTodaysSurgery() {
+        isTodaysSurgerySelected = true
+        selectedPatientID = nil
+    }
+
+    /// 환자 선택
+    public mutating func selectPatient(_ patientID: String) {
+        isTodaysSurgerySelected = false
+        selectedPatientID = patientID
+    }
+
+    /// 환자 생성 시트 열기
+    public mutating func openPatientCreateSheet() {
+        patientInputMode = .create
+        patientToEdit = nil
+        isPresentingPatientInput = true
+    }
+
+    /// 환자 수정 시트 열기
+    public mutating func openPatientEditSheet(patient: PatientDisplayModel) {
+        patientInputMode = .edit
+        patientToEdit = patient
+        isPresentingPatientInput = true
+    }
+
+    /// 수술 생성 시트 열기
+    public mutating func openOperationCreateSheet() {
+        isPresentingOperationInput = true
+    }
+
+    /// 환자 입력 시트 닫기
+    public mutating func closePatientInputSheet() {
+        isPresentingPatientInput = false
+        patientToEdit = nil
+    }
+
+    /// 수술 입력 시트 닫기
+    public mutating func closeOperationInputSheet() {
+        isPresentingOperationInput = false
+    }
+}
+
+// MARK: - PatientInputMode
+
+public enum PatientInputMode {
+    case create
+    case edit
+}

--- a/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
+++ b/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
@@ -1,0 +1,230 @@
+//
+//  MacRootViewModel.swift
+//  HippoMac
+//
+//  Created by Claude on 11/6/25.
+//
+
+import Foundation
+import Observation
+import os.log
+
+/// Mac 앱 전체의 루트 ViewModel
+/// Shared ViewModel을 재사용하고 Mac 전용 네비게이션 상태만 관리
+@MainActor
+@Observable
+public final class MacRootViewModel {
+    // MARK: - Logger
+
+    private let logger = Logger(subsystem: "com.television.hippo.mac", category: "MacRootViewModel")
+
+    // MARK: - Navigation State
+
+    /// Mac 네비게이션 상태
+    public var navigationState = MacNavigationState()
+
+    // MARK: - Input Form States
+
+    /// 환자 입력 폼 상태
+    public var patientInputState = PatientInputState()
+
+    /// 수술 입력 폼 상태
+    public var operationInputState = OperationInputState()
+
+    // MARK: - Shared ViewModels (비즈니스 로직)
+
+    /// Home 화면 ViewModel (Shared 재사용)
+    public let homeViewModel: HomeViewModel
+
+    /// Operation ViewModel (Shared 재사용)
+    public var operationViewModel: OperationViewModel?
+
+    // MARK: - Initialization
+
+    public init() {
+        self.homeViewModel = HomeViewModel()
+        logger.debug("MacRootViewModel initialized with Shared ViewModels")
+    }
+
+    // MARK: - Navigation Actions
+
+    /// 오늘의 수술 화면으로 이동
+    public func selectTodaysSurgery() {
+        navigationState.selectTodaysSurgery()
+        logger.debug("Selected Today's Surgery view")
+    }
+
+    /// 환자 선택
+    public func selectPatient(_ patientID: String) {
+        navigationState.selectPatient(patientID)
+        logger.debug("Selected patient: \(patientID)")
+    }
+
+    /// 환자 생성 시트 열기
+    public func openPatientCreateSheet() {
+        navigationState.openPatientCreateSheet()
+        patientInputState.reset()
+        logger.debug("Opening patient create sheet")
+    }
+
+    /// 환자 수정 시트 열기
+    public func openPatientEditSheet(patient: PatientDisplayModel) {
+        navigationState.openPatientEditSheet(patient: patient)
+        patientInputState = PatientInputState(from: patient)
+        logger.debug("Opening patient edit sheet for: \(patient.name)")
+    }
+
+    /// 수술 생성 시트 열기
+    public func openOperationCreateSheet() {
+        guard let patientID = navigationState.selectedPatientID else {
+            logger.warning("Cannot open operation sheet: no patient selected")
+            return
+        }
+        navigationState.openOperationCreateSheet()
+        operationInputState.reset()
+        logger.debug("Opening operation create sheet for patient: \(patientID)")
+    }
+
+    /// 환자 입력 시트 닫기
+    public func closePatientInputSheet() {
+        navigationState.closePatientInputSheet()
+        patientInputState.reset()
+        logger.debug("Closed patient input sheet")
+    }
+
+    /// 수술 입력 시트 닫기
+    public func closeOperationInputSheet() {
+        navigationState.closeOperationInputSheet()
+        operationInputState.reset()
+        logger.debug("Closed operation input sheet")
+    }
+
+    // MARK: - Patient Actions (Shared ViewModel 위임)
+
+    /// 환자 생성
+    public func createPatient() async -> Bool {
+        await homeViewModel.create(
+            patientNumber: patientInputState.patientNumber,
+            name: patientInputState.name,
+            gender: patientInputState.selectedGender,
+            birthDate: patientInputState.birthDate
+        )
+
+        // state.alert로 성공 여부 판단
+        if homeViewModel.state.alert == nil {
+            closePatientInputSheet()
+            logger.debug("Patient created successfully")
+            return true
+        } else {
+            patientInputState.errorMessage = homeViewModel.state.alert
+            logger.error("Failed to create patient")
+            return false
+        }
+    }
+
+    /// 환자 수정
+    public func updatePatient() async -> Bool {
+        guard let patientID = navigationState.patientToEdit?.id else {
+            logger.error("Cannot update: no patient to edit")
+            return false
+        }
+
+        await homeViewModel.update(
+            patientID: patientID,
+            patientNumber: patientInputState.patientNumber,
+            name: patientInputState.name,
+            gender: patientInputState.selectedGender,
+            birthDate: patientInputState.birthDate
+        )
+
+        // HomeViewModel은 void를 반환하므로 state.alert로 성공 여부 판단
+        if homeViewModel.state.alert == nil {
+            closePatientInputSheet()
+            logger.debug("Patient updated successfully")
+            return true
+        } else {
+            patientInputState.errorMessage = homeViewModel.state.alert
+            logger.error("Failed to update patient")
+            return false
+        }
+    }
+
+    /// 환자 삭제
+    public func deletePatient(_ patientID: String) async {
+        await homeViewModel.remove(patientID: patientID)
+        logger.debug("Patient deleted")
+    }
+
+    // MARK: - Operation Actions (Shared ViewModel 위임)
+
+    /// 수술 생성
+    public func createOperation() async -> Bool {
+        guard let patientID = navigationState.selectedPatientID else {
+            logger.error("Cannot create operation: no patient selected")
+            return false
+        }
+
+        // DisplayModel을 Domain OperationAsset으로 변환
+        let operationAssets = operationInputState.assets.map { $0.toDomain() }
+
+        await homeViewModel.addOperation(
+            toPatientID: patientID,
+            title: operationInputState.title,
+            diagnosis: operationInputState.diagnosis,
+            surgeon: operationInputState.surgeon,
+            surgicalSite: operationInputState.surgicalSite,
+            date: operationInputState.operationDate,
+            details: operationInputState.details,
+            status: .planned
+        )
+
+        // HomeViewModel은 void를 반환하므로 state.alert로 성공 여부 판단
+        if homeViewModel.state.alert == nil {
+            closeOperationInputSheet()
+            logger.debug("Operation created successfully")
+            return true
+        } else {
+            operationInputState.errorMessage = homeViewModel.state.alert
+            logger.error("Failed to create operation")
+            return false
+        }
+    }
+
+    /// 수술 삭제
+    public func deleteOperation(operationID: String) async {
+        guard let patientID = navigationState.selectedPatientID else {
+            logger.error("Cannot delete operation: no patient selected")
+            return
+        }
+
+        await homeViewModel.removeOperation(operationID: operationID, fromPatientID: patientID)
+        logger.debug("Operation deleted")
+    }
+
+    // MARK: - Data Loading
+
+    /// 전체 데이터 로드
+    public func load() async {
+        await homeViewModel.load()
+        logger.debug("Loaded all data")
+    }
+
+    /// 특정 환자 로드
+    public func loadPatient(_ patientID: String) async {
+        await homeViewModel.load(patientID: patientID)
+        logger.debug("Loaded patient: \(patientID)")
+    }
+
+    // MARK: - Computed Properties
+
+    /// 현재 선택된 환자 정보
+    public var selectedPatient: PatientDisplayModel? {
+        guard let patientID = navigationState.selectedPatientID else { return nil }
+        return homeViewModel.state.items.first { $0.id == patientID }
+    }
+
+    /// 선택된 환자의 수술 목록
+    public var selectedPatientOperations: [OperationDisplayModel] {
+        selectedPatient?.operations ?? []
+    }
+}

--- a/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
+++ b/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
@@ -8,11 +8,14 @@
 import SwiftUI
 
 struct TodaysSurgeryView: View {
+    // HomeView의 homeViewModel 전달받기 (todayOperations 사용)
+    let viewModel: HomeViewModel
+
     var body: some View {
         Text("오늘의 수술이 없습니다.")
     }
 }
 
 #Preview {
-    TodaysSurgeryView()
+    TodaysSurgeryView(viewModel: HomeViewModel())
 }


### PR DESCRIPTION
## 📕 Issue Number

Close #117 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

Mac용 View에서 ViewModel의 public 함수 호출을 통해 Patient/Operation 데이터를 사용할 수 있도록 구현했습니다.

   - [x] **MacRootViewModel 구조 설계 및 구현**
     - Shared ViewModel(HomeViewModel) 재사용하여 비즈니스 로직 중복 제거
     - Mac 전용 네비게이션 상태 관리 (MacNavigationState)
     - Patient/Operation CRUD 작업을 Shared ViewModel에 위임

   - [x] **State 객체 분리**
     - PatientInputState: 환자 입력 폼 상태 관리
     - OperationInputState: 수술 입력 폼 상태 관리
     - MacNavigationState: 화면 전환 및 시트 표시 상태 관리

   - [x] **PatientDetailViewModel 구현**
     - MacRootViewModel의 데이터 재사용
     - 환자 상세 정보 및 수술 목록 제공
     - 환자/수술 삭제 기능 위임

   - [x] **View-ViewModel 바인딩**
     - HomeView: rootVM 초기화 및 하위 View에 전달
     - PatientDetailView: PatientDetailViewModel 연동
     - PatientInputView: PatientInputState 바인딩 및 onSave 콜백 연결
     - OperationInputView: OperationInputState 바인딩 및 onSave 콜백 연결
     - TodaysSurgeryView: homeViewModel 전달

## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

- 스크린 샷


## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- **Shared ViewModel 재사용**: Vision 앱과 동일한 비즈니스 로직(HomeViewModel)을 재사용하여 코드 중복을 최소화했습니다.
- **관심사 분리**: MacRootViewModel은 Mac 전용 네비게이션과 State 관리만 담당하고, 실제 비즈니스 로직은 Shared ViewModel에 위임합니다.
- [TODO]: 추후 Mock 데이터를 ViewModel 데이터로 완전히 교체

<br><br>
