### PR TITLE
Feature/#139 모든 뷰와 뷰모델 연결 완료

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		065DA5582EBD844600B454BC /* PatientButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065DA5572EBD844600B454BC /* PatientButtonView.swift */; };
+		065DA55A2EBDD12000B454BC /* OperationCardDisplayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065DA5592EBDD12000B454BC /* OperationCardDisplayModel.swift */; };
 		0667A53A2EB79DBB00D7BDF3 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667A5392EB79DBB00D7BDF3 /* HomeView.swift */; };
 		0667A54A2EB8814100D7BDF3 /* StreamingControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667A5492EB8814100D7BDF3 /* StreamingControlView.swift */; };
 		0667A54C2EB8833D00D7BDF3 /* PatientDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0667A54B2EB8833D00D7BDF3 /* PatientDetailView.swift */; };
@@ -349,6 +350,7 @@
 
 /* Begin PBXFileReference section */
 		065DA5572EBD844600B454BC /* PatientButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientButtonView.swift; sourceTree = "<group>"; };
+		065DA5592EBDD12000B454BC /* OperationCardDisplayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCardDisplayModel.swift; sourceTree = "<group>"; };
 		0667A5392EB79DBB00D7BDF3 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		0667A5492EB8814100D7BDF3 /* StreamingControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingControlView.swift; sourceTree = "<group>"; };
 		0667A54B2EB8833D00D7BDF3 /* PatientDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatientDetailView.swift; sourceTree = "<group>"; };
@@ -585,6 +587,7 @@
 			isa = PBXGroup;
 			children = (
 				06ADD9CC2EB98B3D0013665B /* OperationListView.swift */,
+				065DA5592EBDD12000B454BC /* OperationCardDisplayModel.swift */,
 				06BF173D2EBB27C700996C86 /* OperationCardView.swift */,
 				06BF173B2EBB25AF00996C86 /* OperationMockDataModel.swift */,
 				06F9D6352EBC765A00AD1EE6 /* OperationInputView.swift */,
@@ -1841,6 +1844,7 @@
 				06F9D6362EBC765A00AD1EE6 /* OperationInputView.swift in Sources */,
 				25E78B852EB9166900D8CAD2 /* OperationWithPatient.swift in Sources */,
 				06F8CAC32EBA459B00926483 /* StreamingInspectorView.swift in Sources */,
+				065DA55A2EBDD12000B454BC /* OperationCardDisplayModel.swift in Sources */,
 				25E78B732EB9164200D8CAD2 /* OperationRepository.swift in Sources */,
 				25E78B662EB90D4600D8CAD2 /* OperationStatus.swift in Sources */,
 				25E78B672EB90D4600D8CAD2 /* Operation.swift in Sources */,

--- a/Hippo/Features/Mac/UI/Home/HomeView.swift
+++ b/Hippo/Features/Mac/UI/Home/HomeView.swift
@@ -29,7 +29,8 @@ struct HomeView: View {
                     //환자 리스트에 데이터가 있는 경우
                     ForEach(rootVM.loadedPatients, id: \.id) { data in
                         HStack {
-                            Button { rootVM.selectPatient(data.id)
+                            Button {
+                                rootVM.selectPatient(data.id)
                             } label: {
                                 HStack {
                                     Text(data.patientNumber)
@@ -39,22 +40,30 @@ struct HomeView: View {
                                 }
                             }
                             .onHover { hovering in
-                                hoveredPatientID = hovering ? data.id : (hoveredPatientID == data.id ? nil : hoveredPatientID)
+                                hoveredPatientID =
+                                    hovering
+                                    ? data.id
+                                    : (hoveredPatientID == data.id
+                                        ? nil : hoveredPatientID)
                             }
 
                             Button {
-                                // TODO: 환자 수정&삭제
-//                                rootVM.openPatientEditSheet(patient: data)
-                                Task {
-                                    await rootVM.deletePatient(data.id)
-                                }
-                                
+                                // 환자 수정 버튼
+                                rootVM.openPatientEditSheet(patient: data)
+                                //                                Task {
+                                //                                    await rootVM.deletePatient(data.id)
+                                //                                }
+
                             } label: {
                                 Image(systemName: "ellipsis.circle")
                             }
                             .opacity(hoveredPatientID == data.id ? 1 : 0)
                             .onHover { hovering in
-                                hoveredPatientID = hovering ? data.id : (hoveredPatientID == data.id ? nil : hoveredPatientID)
+                                hoveredPatientID =
+                                    hovering
+                                    ? data.id
+                                    : (hoveredPatientID == data.id
+                                        ? nil : hoveredPatientID)
                             }
                         }
                     }
@@ -76,8 +85,10 @@ struct HomeView: View {
         } detail: {
 
             if rootVM.isTodaysSurgerySelected {
-                TodaysSurgeryView(viewModel: TodaysSurgeryViewModel(rootVM: rootVM))
-                    .navigationTitle("Today's Surgery")
+                TodaysSurgeryView(
+                    viewModel: TodaysSurgeryViewModel(rootVM: rootVM)
+                )
+                .navigationTitle("Today's Surgery")
             } else {
                 PatientDetailView(
                     viewModel: PatientDetailViewModel(rootVM: rootVM),
@@ -88,6 +99,7 @@ struct HomeView: View {
         }
         .toolbar {
             if !rootVM.isTodaysSurgerySelected {
+                //수술 생성 버튼
                 Button {
                     rootVM.openOperationCreateSheet()
                 } label: {
@@ -118,9 +130,14 @@ struct HomeView: View {
                 isPresentingOperationInput: $rootVM.navigationState
                     .isPresentingOperationInput,
                 state: $rootVM.operationInputState,
+                mode: rootVM.navigationState.operationInputMode,
                 onSave: {
                     Task {
-                        await rootVM.createOperation()
+                        if rootVM.navigationState.operationInputMode == .create {
+                            await rootVM.createOperation()
+                        } else {
+                            await rootVM.updateOperation()
+                        }
                     }
                 }
             )
@@ -143,4 +160,3 @@ struct HomeView: View {
 #Preview {
     RootView()
 }
-

--- a/Hippo/Features/Mac/UI/Home/HomeView.swift
+++ b/Hippo/Features/Mac/UI/Home/HomeView.swift
@@ -28,14 +28,14 @@ struct HomeView: View {
 
                     //환자 리스트에 데이터가 있는 경우
                     ForEach(rootVM.loadedPatients, id: \.id) { data in
-                        //TODO: 컴포넌트로 분리하기. 뷰가 해석을 못 함
                         HStack {
-                            Button { rootVM.selectPatient(data.id)} label: {
+                            Button { rootVM.selectPatient(data.id)
+                            } label: {
                                 HStack {
                                     Text(data.patientNumber)
                                     Text(data.name)
                                     Text(data.genderText)
-                                    Text("\(data.age)세")
+                                    Text("Age \(data.age)")
                                 }
                             }
                             .onHover { hovering in
@@ -44,10 +44,18 @@ struct HomeView: View {
 
                             Button {
                                 // TODO: 환자 수정&삭제
+//                                rootVM.openPatientEditSheet(patient: data)
+                                Task {
+                                    await rootVM.deletePatient(data.id)
+                                }
+                                
                             } label: {
                                 Image(systemName: "ellipsis.circle")
                             }
                             .opacity(hoveredPatientID == data.id ? 1 : 0)
+                            .onHover { hovering in
+                                hoveredPatientID = hovering ? data.id : (hoveredPatientID == data.id ? nil : hoveredPatientID)
+                            }
                         }
                     }
                 } header: {
@@ -81,7 +89,6 @@ struct HomeView: View {
         .toolbar {
             if !rootVM.isTodaysSurgerySelected {
                 Button {
-                    //TODO: 수술 생성 기능 구현
                     rootVM.openOperationCreateSheet()
                 } label: {
                     Label("Create", systemImage: "plus")
@@ -122,7 +129,7 @@ struct HomeView: View {
             // 데이터 로드 (비어 있으면 목업 주입 후 실제 로드)
             await rootVM.load()
 
-            // 목업 데이터 주입
+            // 비어 있으면 목업 데이터 주입
             if rootVM.homeViewModel.state.items.isEmpty {
                 rootVM.homeViewModel.state.items = [
                     PatientDisplayModel.MockData

--- a/Hippo/Features/Mac/UI/Home/PatientButtonView.swift
+++ b/Hippo/Features/Mac/UI/Home/PatientButtonView.swift
@@ -21,7 +21,7 @@ struct PatientButtonView: View {
                     Text(data.patientNumber)
                     Text(data.name)
                     Text(data.genderText)
-                    Text("\(data.age)세")
+                    Text("Age: \(data.age)")
                 }
             }
 

--- a/Hippo/Features/Mac/UI/Operation/OperationCardDisplayModel.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationCardDisplayModel.swift
@@ -1,0 +1,54 @@
+//
+//  OperationListViewDataModel.swift
+//  HippoMac
+//
+//  Created by Hyeok Cho on 11/7/25.
+//
+
+import Foundation
+
+///OperationCardView용 데이터 모델
+public struct OperationCardDisplayModel: Equatable, Identifiable {
+    
+    /// 수술 id
+    public var id: String = ""
+    
+    /// 환자 id
+    public var patientId: String = ""
+    
+    /// 이름
+    public var name: String? = nil
+
+    /// 성별
+    public var gender: String? = nil
+    
+    /// 생년월일
+    public var birthDate: Date? = nil
+    
+    /// 수술 제목
+    public var title: String = ""
+
+    /// 진단(병명)
+    public var diagnosis: String = ""
+
+    /// 집도의
+    public var surgeon: String = ""
+
+    /// 수술 부위
+    public var surgicalSite: String = ""
+
+    /// 수술 날짜
+    public var operationDate: Date = Date()
+
+    /// 수술 상세
+    public var details: String = ""
+
+    /// 3D 모델 에셋 목록
+    public var assets: [OperationAssetDisplayModel] = []
+
+    
+    /// 나이(문자열)
+    public var age: String {
+        String(max(Calendar.current.dateComponents([.year], from: birthDate ?? Date(), to: Date()).year ?? 0, 0))
+    }
+}

--- a/Hippo/Features/Mac/UI/Operation/OperationCardDisplayModel.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationCardDisplayModel.swift
@@ -8,47 +8,58 @@
 import Foundation
 
 ///OperationCardView용 데이터 모델
-public struct OperationCardDisplayModel: Equatable, Identifiable {
-    
-    /// 수술 id
-    public var id: String = ""
-    
-    /// 환자 id
-    public var patientId: String = ""
-    
-    /// 이름
-    public var name: String? = nil
+public struct OperationCardDisplayModel: Equatable, Identifiable, Sendable {
+    public let id: String
+    public let patientId: String
+    public let name: String?
+    public let gender: String?
+    public let birthDate: Date?
+    public let title: String
+    public let diagnosis: String
+    public let surgeon: String
+    public let surgicalSite: String
+    public let operationDate: Date
+    public let details: String
+    public let assets: [OperationAssetDisplayModel]
 
-    /// 성별
-    public var gender: String? = nil
-    
-    /// 생년월일
-    public var birthDate: Date? = nil
-    
-    /// 수술 제목
-    public var title: String = ""
-
-    /// 진단(병명)
-    public var diagnosis: String = ""
-
-    /// 집도의
-    public var surgeon: String = ""
-
-    /// 수술 부위
-    public var surgicalSite: String = ""
-
-    /// 수술 날짜
-    public var operationDate: Date = Date()
-
-    /// 수술 상세
-    public var details: String = ""
-
-    /// 3D 모델 에셋 목록
-    public var assets: [OperationAssetDisplayModel] = []
-
-    
-    /// 나이(문자열)
     public var age: String {
-        String(max(Calendar.current.dateComponents([.year], from: birthDate ?? Date(), to: Date()).year ?? 0, 0))
+        String(
+            max(
+                Calendar.current.dateComponents(
+                    [.year],
+                    from: birthDate ?? Date(),
+                    to: Date()
+                ).year ?? 0,
+                0
+            )
+        )
+    }
+
+    public init(
+        id: String,
+        patientId: String,
+        name: String? = nil,
+        gender: String? = nil,
+        birthDate: Date? = nil,
+        title: String,
+        diagnosis: String,
+        surgeon: String,
+        surgicalSite: String,
+        operationDate: Date,
+        details: String,
+        assets: [OperationAssetDisplayModel]
+    ) {
+        self.id = id
+        self.patientId = patientId
+        self.name = name
+        self.gender = gender
+        self.birthDate = birthDate
+        self.title = title
+        self.diagnosis = diagnosis
+        self.surgeon = surgeon
+        self.surgicalSite = surgicalSite
+        self.operationDate = operationDate
+        self.details = details
+        self.assets = assets
     }
 }

--- a/Hippo/Features/Mac/UI/Operation/OperationCardView.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationCardView.swift
@@ -40,7 +40,7 @@ struct OperationCardView: View {
                 HStack {
                     Button {
                         //TODO: 수술 수정
-//                        onEdit()
+                        onEdit(operation.id)
                     } label: {
                         Image(systemName: "square.and.pencil")
                     }

--- a/Hippo/Features/Mac/UI/Operation/OperationCardView.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationCardView.swift
@@ -10,7 +10,10 @@ import SwiftUI
 struct OperationCardView: View {
     @State var isCardCollapsed: Bool = false
 
-    let operation: OperationDisplayModel
+    let operation: OperationCardDisplayModel
+    
+    let onEdit: (String) -> Void
+    let onDelete: (String) -> Void
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -29,7 +32,7 @@ struct OperationCardView: View {
 
                 VStack(alignment: .leading) {
                     Text(operation.title)
-                    Text(operation.dateText)
+                    Text("\(operation.operationDate)")
                 }
 
                 Spacer()
@@ -37,11 +40,13 @@ struct OperationCardView: View {
                 HStack {
                     Button {
                         //TODO: 수술 수정
+//                        onEdit()
                     } label: {
                         Image(systemName: "square.and.pencil")
                     }
                     Button {
                         //TODO: 수술 삭제
+                        onDelete(operation.id)
                     } label: {
                         Image(systemName: "trash")
                     }
@@ -57,18 +62,28 @@ struct OperationCardView: View {
                 Divider()
 
                 //환자정보/집도의/수술부위/진단(병명)
+                
                 HStack {
-
-                    VStack(alignment: .leading) {
-                        Text("환자 정보")
-                            .padding(.vertical, 4)
-                        Text("이름 성별 / 나이")
+                    
+                    if let name = operation.name,
+                        let gender = operation.gender {
+                        VStack(alignment: .leading) {
+                            Text("Patient Info")
+                                .padding(.vertical, 4)
+                            HStack {
+                                Text(name)
+                                Text("/")
+                                Text(gender)
+                                Text("/")
+                                Text(operation.age)
+                            }
+                        }
+                        
+                        Spacer()
                     }
-
-                    Spacer()
-
+                    
                     VStack(alignment: .leading) {
-                        Text("집도의")
+                        Text("Surgeon")
                             .padding(.vertical, 4)
                         Text(operation.surgeon)
                     }
@@ -76,7 +91,7 @@ struct OperationCardView: View {
                     Spacer()
 
                     VStack(alignment: .leading) {
-                        Text("수술 부위")
+                        Text("Surgical Site")
                             .padding(.vertical, 4)
                         Text(operation.surgicalSite)
                     }
@@ -84,7 +99,7 @@ struct OperationCardView: View {
                     Spacer()
 
                     VStack(alignment: .leading) {
-                        Text("진단(병명)")
+                        Text("Diagnosis")
                             .padding(.vertical, 4)
                         Text(operation.diagnosis)
                     }
@@ -96,7 +111,7 @@ struct OperationCardView: View {
 
                 //상세 내용
                 VStack(alignment: .leading) {
-                    Text("상세 내용")
+                    Text("Details")
                         .padding(.vertical, 4)
                     Text(operation.details)
                 }
@@ -104,16 +119,16 @@ struct OperationCardView: View {
                 Divider()
 
                 VStack(alignment: .leading) {
-                    Text("3D 모델 파일")
+                    Text("3D models")
                         .padding(.vertical, 4)
 
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 12) {
                             //TODO: 3D 모델 파일로 UI 테스트 필요
                             //TODO: 마우스 호버 시, 배경 Dim처리 + 삭제 버튼 활성화
-                            ForEach(0..<10) { index in
-                                Rectangle()
-                                    .frame(width: 50, height: 50)
+                            ForEach(operation.assets) { asset in
+                                // 썸네일을 준비하지 않았다면 파일명만 먼저
+                                Text(asset.fileName)
                             }
                         }
                         .padding(.vertical)

--- a/Hippo/Features/Mac/UI/Operation/OperationInputView.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationInputView.swift
@@ -16,32 +16,35 @@ struct OperationInputView: View {
     let onSave: () async -> Void
 
     var body: some View {
-        Section(header: Text("수술 추가하기")) {
-            
+        Section(header: Text("Add Operation")) {
+
             //텍스트필드 영역
             Form {
-                TextField("수술 타이틀", text: $state.title)
+                TextField("Title", text: $state.title)
                 HStack {
-                    DatePicker("수술날짜", selection: $state.operationDate)
-                        .environment(\.locale, Locale(identifier: "ko_KR"))
+                    DatePicker(
+                        "Operation Date",
+                        selection: $state.operationDate
+                    )
+                    .environment(\.locale, Locale(identifier: "ko_KR"))
                 }
-                TextField("집도의 성명", text: $state.surgeon)
-                TextField("수술부위", text: $state.surgicalSite)
-                TextField("진단(병명)", text: $state.diagnosis)
-                TextField("수술상세", text: $state.details, axis: .vertical)
+                TextField("Surgeon", text: $state.surgeon)
+                TextField("Surgical Site", text: $state.surgicalSite)
+                TextField("Diagnosis", text: $state.diagnosis)
+                TextField("Details", text: $state.details, axis: .vertical)
                     .lineLimit(5...10)
             }
-            
+
             //3D 모델링 추가 뷰
             HStack {
-                Text("3D 모델링 파일")
+                Text("3D Models")
 
                 Spacer()
-                
+
                 Button {
                     let selections = state.pickAssets()
                     for (url, fileName) in selections {
-                        state.addAsset(fileURL: url, fileName: fileName) // 한 번에 하나씩 추가
+                        state.addAsset(fileURL: url, fileName: fileName)  // 한 번에 하나씩 추가
                     }
                 } label: {
                     Image(systemName: "plus")
@@ -63,14 +66,12 @@ struct OperationInputView: View {
 
         //취소/저장 버튼
         HStack {
-            Button("취소") {
+            Button("Cancel") {
                 isPresentingOperationInput = false
             }
-            Button("저장") {
-                if state.isValid {
-                    Task {
-                        await onSave()
-                    }
+            Button("Save") {
+                Task {
+                    await onSave()
                 }
                 isPresentingOperationInput = false
             }
@@ -78,7 +79,6 @@ struct OperationInputView: View {
         .padding()
     }
 
-    
 }
 
 #Preview {
@@ -86,6 +86,6 @@ struct OperationInputView: View {
     OperationInputView(
         isPresentingOperationInput: .constant(true),
         state: $state,
-        onSave: { }
+        onSave: {}
     )
 }

--- a/Hippo/Features/Mac/UI/Operation/OperationInputView.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationInputView.swift
@@ -13,6 +13,8 @@ struct OperationInputView: View {
 
     // ViewModel State 바인딩 (HomeView의 rootVM에서 전달받음)
     @Binding var state: OperationInputState
+    let mode: OperationInputMode
+    
     let onSave: () async -> Void
 
     var body: some View {
@@ -70,6 +72,12 @@ struct OperationInputView: View {
                 isPresentingOperationInput = false
             }
             Button("Save") {
+                if mode == .create {
+                    print("operation created")
+                } else {
+                    print("operation edited")
+                }
+                
                 Task {
                     await onSave()
                 }
@@ -86,6 +94,7 @@ struct OperationInputView: View {
     OperationInputView(
         isPresentingOperationInput: .constant(true),
         state: $state,
+        mode: .create,
         onSave: {}
     )
 }

--- a/Hippo/Features/Mac/UI/Operation/OperationListView.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationListView.swift
@@ -60,7 +60,6 @@ struct OperationListView: View {
                                 onEdit: onEdit,
                                 onDelete: onDelete
                             )
-
                         }
                     } header: {
                         HStack {

--- a/Hippo/Features/Mac/UI/Operation/OperationListView.swift
+++ b/Hippo/Features/Mac/UI/Operation/OperationListView.swift
@@ -7,40 +7,47 @@
 
 import SwiftUI
 
-struct OperationListView: View {//TODO: 실제 데이터 연결 시에는 환자정보도 같이 가져와야 할 듯?
-    
-    var operations: [OperationDisplayModel]
-    let onDelete: (OperationDisplayModel) -> Void //TODO: 이거 맞는지 확인 필요
-    
+struct OperationListView: View {
+
+    var operations: [OperationCardDisplayModel]
+    let onEdit: (String) -> Void
+    let onDelete: (String) -> Void
+
     @State var now = Date()
-    
+
     var body: some View {
         if operations.isEmpty {
             Text("입력된 수술이 없습니다.")
                 .padding()
         } else {
-            // 오늘을 기준으로 수술 데이터 나누기
-            let upcoming = operations //TODO: 실제 데이터 배열과 연결하기
-                .filter { $0.date > now }
-                .sorted { $0.date < $1.date }
-            let finished = operations //TODO: 실제 데이터 배열과 연결하기
-                .filter { $0.date <= now }
-                .sorted { $0.date > $1.date }
-            
+            // 오늘을 기준으로 수술 카드 나누기
+            let upcoming =
+                operations  //TODO: 실제 데이터 배열과 연결하기
+                .filter { $0.operationDate > now }
+                .sorted { $0.operationDate < $1.operationDate }
+            let finished =
+                operations  //TODO: 실제 데이터 배열과 연결하기
+                .filter { $0.operationDate <= now }
+                .sorted { $0.operationDate > $1.operationDate }
+
             // TODO: 리스트 뷰 or 스크롤 뷰 선택
             // TODO: 수술 디테일 카드뷰 추가
 
             ScrollView {
-                LazyVStack() {
-                    
+                LazyVStack {
+
                     // 대기 수술 섹션
                     Section {
                         ForEach(upcoming) { sample in
-                            OperationCardView(operation: sample)
+                            OperationCardView(
+                                operation: sample,
+                                onEdit: onEdit,
+                                onDelete: onDelete
+                            )
                         }
                     } header: {
                         HStack {
-                            Text("대기 수술")
+                            Text("Scheduled Surgery")
                             Spacer()
                         }
                     }
@@ -48,15 +55,20 @@ struct OperationListView: View {//TODO: 실제 데이터 연결 시에는 환자
                     // 완료 수술 섹션
                     Section {
                         ForEach(finished) { sample in
-                            OperationCardView(operation: sample)
+                            OperationCardView(
+                                operation: sample,
+                                onEdit: onEdit,
+                                onDelete: onDelete
+                            )
+
                         }
                     } header: {
                         HStack {
-                            Text("완료 수술")
+                            Text("Completed Surgery")
                             Spacer()
                         }
                     }
-                    
+
                 }
                 .padding()
             }
@@ -67,4 +79,3 @@ struct OperationListView: View {//TODO: 실제 데이터 연결 시에는 환자
 //#Preview {
 //    OperationListView(operationMockData:)
 //}
-

--- a/Hippo/Features/Mac/UI/Patient/PatientDetailView.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientDetailView.swift
@@ -11,8 +11,6 @@ struct PatientDetailView: View {
     // ViewModel 초기화 (HomeView에서 rootVM 전달받음)
     let viewModel: PatientDetailViewModel
 
-    // Mock 데이터 (UI 개발용)
-    var mockData = HomeMockDataModel.mockList
 
     var selectedPatient: PatientDisplayModel?
     
@@ -21,16 +19,18 @@ struct PatientDetailView: View {
     var body: some View {
 
         OperationListView(
-            operations: viewModel.operations,
+            operations: viewModel.operationCards,
+            onEdit: { operationID in
+                //TODO: 수술 수정
+            },
             onDelete: { operationID in
-//                Task {
-//                    await viewModel.deleteOperation(operationID)
-//                }
-                //TODO: 원띵과 논의 필요
+                Task {
+                    await viewModel.deleteOperation(operationID)
+                }
             }
         )
-        .navigationTitle(selectedPatient.map { "\($0.name) \($0.gender) \($0.age)세" } ?? "환자 상세 정보")
-        .navigationSubtitle(selectedPatient?.patientNumber ?? "환자 번호")
+        .navigationTitle(selectedPatient.map { "\($0.name) \($0.gender) Age\($0.age)" } ?? "환자 상세 정보")
+        .navigationSubtitle(selectedPatient?.patientNumber ?? "Patient Number")
     }
 }
 
@@ -40,7 +40,6 @@ struct PatientDetailView: View {
     let rootVM = MacRootViewModel()
     PatientDetailView(
         viewModel: PatientDetailViewModel(rootVM: rootVM),
-//        patientId: "",
         isTodaysSurgerySelected: isTodaysSurgery
     )
 }

--- a/Hippo/Features/Mac/UI/Patient/PatientDetailView.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientDetailView.swift
@@ -11,17 +11,21 @@ struct PatientDetailView: View {
     // ViewModel 초기화 (HomeView에서 rootVM 전달받음)
     let viewModel: PatientDetailViewModel
 
-
     var selectedPatient: PatientDisplayModel?
-    
+
     var isTodaysSurgerySelected: Bool
-    
+
     var body: some View {
 
         OperationListView(
             operations: viewModel.operationCards,
             onEdit: { operationID in
-                //TODO: 수술 수정
+                viewModel.selectedOperationID = operationID
+                //수술 수정 시트 열기
+                //Patient수정과 다르게 id를 전달받아서 OperationDisplayModel을 반환하는 헬퍼함수를 추가했습니다.
+                if let op = viewModel.operation(by: operationID) {
+                    viewModel.openOperationEditSheet(operation: op)
+                }
             },
             onDelete: { operationID in
                 Task {
@@ -29,17 +33,21 @@ struct PatientDetailView: View {
                 }
             }
         )
-        .navigationTitle(selectedPatient.map { "\($0.name) \($0.gender) Age\($0.age)" } ?? "환자 상세 정보")
+        .navigationTitle(
+            selectedPatient.map { "\($0.name) \($0.gender) Age\($0.age)" }
+                ?? "환자 상세 정보"
+        )
         .navigationSubtitle(selectedPatient?.patientNumber ?? "Patient Number")
     }
 }
 
 #Preview {
     @Previewable @State var isTodaysSurgery: Bool = false
-    
+
     let rootVM = MacRootViewModel()
     PatientDetailView(
         viewModel: PatientDetailViewModel(rootVM: rootVM),
         isTodaysSurgerySelected: isTodaysSurgery
     )
 }
+

--- a/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
@@ -15,21 +15,6 @@ public final class PatientDetailViewModel {
         self.rootVM = rootVM
     }
     
-    public var isPresentingOperationInput: Bool {
-        get { rootVM.navigationState.isPresentingOperationInput }
-        set { rootVM.navigationState.isPresentingOperationInput = newValue }
-    }
-
-    public var operationInputMode: OperationInputMode {
-        get { rootVM.navigationState.operationInputMode }
-        set { rootVM.navigationState.operationInputMode = newValue}
-    }
-    
-    public var operationInputState: OperationInputState {
-        get { rootVM.operationInputState }
-        set { rootVM.operationInputState = newValue }
-    }
-    
     public var selectedOperationID: String? {
         get { rootVM.navigationState.selectedOperationID }
         set { rootVM.navigationState.selectedOperationID = newValue }
@@ -46,27 +31,8 @@ public final class PatientDetailViewModel {
     public var operations: [OperationDisplayModel] {
         rootVM.selectedPatientOperations
     }
-
-    // MARK: - Actions (rootVM 위임)
-
-    /// 환자 삭제
-    public func deletePatient() async {
-        guard let patientID = patient?.id else { return }
-        await rootVM.deletePatient(patientID)
-    }
-
-    /// 수술 삭제
-    public func deleteOperation(_ operationID: String) async {
-        await rootVM.deleteOperation(operationID: operationID)
-    }
     
-    /// 데이터 새로고침
-    public func refresh() async {
-        await rootVM.load()
-    }
-}
-
-extension PatientDetailViewModel {
+    /// 수술 카드뷰로 변환 OperationDisplayModel -> OperationCardDisplayModel
     public var operationCards: [OperationCardDisplayModel] {
         guard let patient = patient else { return [] }
         return operations.map { op in
@@ -86,6 +52,8 @@ extension PatientDetailViewModel {
             )
         }
     }
+
+    // MARK: - Actions (rootVM 위임)
     
     /// 수술 수정 시트 열기. 추가됨
     public func openOperationEditSheet(operation: OperationDisplayModel) {
@@ -96,5 +64,24 @@ extension PatientDetailViewModel {
     public func operation(by id: String) -> OperationDisplayModel? {
         operations.first { $0.id == id }
     }
+
+    /// 환자 삭제
+    public func deletePatient() async {
+        guard let patientID = patient?.id else { return }
+        await rootVM.deletePatient(patientID)
+    }
+
+    /// 수술 삭제
+    public func deleteOperation(_ operationID: String) async {
+        await rootVM.deleteOperation(operationID: operationID)
+    }
+    
+    /// 데이터 새로고침
+    public func refresh() async {
+        await rootVM.load()
+    }
+}
+
+extension PatientDetailViewModel {
 
 }

--- a/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
@@ -11,6 +11,8 @@ public final class PatientDetailViewModel {
     public init(rootVM: MacRootViewModel) {
         self.rootVM = rootVM
     }
+    
+    public var operationCardDisplayModel = OperationCardDisplayModel()
 
     // MARK: - Computed Properties (rootVM 재사용)
 
@@ -35,5 +37,32 @@ public final class PatientDetailViewModel {
     /// 수술 삭제
     public func deleteOperation(_ operationID: String) async {
         await rootVM.deleteOperation(operationID: operationID)
+    }
+    
+    /// 데이터 새로고침
+    public func refresh() async {
+        await rootVM.load()
+    }
+}
+
+extension PatientDetailViewModel {
+    public var operationCards: [OperationCardDisplayModel] {
+        guard let patient = patient else { return [] }
+        return operations.map { op in
+            OperationCardDisplayModel(
+                id: op.id,
+                patientId: patient.id,
+                name: nil,
+                gender: nil,
+                birthDate: nil,
+                title: op.title,
+                diagnosis: op.diagnosis,
+                surgeon: op.surgeon,
+                surgicalSite: op.surgicalSite,
+                operationDate: op.date,
+                details: op.details,
+                assets: op.assets
+            )
+        }
     }
 }

--- a/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientDetailViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os.log
 
 /// 환자 상세 화면의 ViewModel
 /// MacRootViewModel의 데이터를 재사용하여 환자 정보 제공
@@ -7,18 +8,38 @@ import Observation
 @Observable
 public final class PatientDetailViewModel {
     private let rootVM: MacRootViewModel
+    
+    private let logger = Logger(subsystem: "com.television.hippo.mac", category: "MacRootViewModel")
 
     public init(rootVM: MacRootViewModel) {
         self.rootVM = rootVM
     }
     
-    public var operationCardDisplayModel = OperationCardDisplayModel()
+    public var isPresentingOperationInput: Bool {
+        get { rootVM.navigationState.isPresentingOperationInput }
+        set { rootVM.navigationState.isPresentingOperationInput = newValue }
+    }
+
+    public var operationInputMode: OperationInputMode {
+        get { rootVM.navigationState.operationInputMode }
+        set { rootVM.navigationState.operationInputMode = newValue}
+    }
+    
+    public var operationInputState: OperationInputState {
+        get { rootVM.operationInputState }
+        set { rootVM.operationInputState = newValue }
+    }
+    
+    public var selectedOperationID: String? {
+        get { rootVM.navigationState.selectedOperationID }
+        set { rootVM.navigationState.selectedOperationID = newValue }
+    }
 
     // MARK: - Computed Properties (rootVM 재사용)
 
     /// 현재 선택된 환자
     public var patient: PatientDisplayModel? {
-        rootVM.selectedPatient
+        get { rootVM.selectedPatient }
     }
 
     /// 선택된 환자의 수술 목록
@@ -65,4 +86,15 @@ extension PatientDetailViewModel {
             )
         }
     }
+    
+    /// 수술 수정 시트 열기. 추가됨
+    public func openOperationEditSheet(operation: OperationDisplayModel) {
+        rootVM.openOperationEditSheet(operation: operation)
+    }
+    
+    /// 하위 뷰로부터 받은 ID 기반으로 수술 조회. 추가됨
+    public func operation(by id: String) -> OperationDisplayModel? {
+        operations.first { $0.id == id }
+    }
+
 }

--- a/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
@@ -19,10 +19,10 @@ struct PatientInputView: View {
         Section(header: Text("Add Patient")) {
             Form {
                 TextField("Patient Number", text: $state.patientNumber)
-                TextField("name", text: $state.name)
-                Picker("gender", selection: $state.selectedGender) {
-                    Text("male").tag(Gender.male)
-                    Text("female").tag(Gender.female)
+                TextField("Name", text: $state.name)
+                Picker("Gender", selection: $state.selectedGender) {
+                    Text("Male").tag(Gender.male)
+                    Text("Female").tag(Gender.female)
                 }
                 .pickerStyle(.segmented)
                 HStack {

--- a/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
+++ b/Hippo/Features/Mac/UI/Patient/PatientInputView.swift
@@ -16,23 +16,23 @@ struct PatientInputView: View {
     let onSave: () async -> Void
 
     var body: some View {
-        Section(header: Text("환자 추가하기")) {
+        Section(header: Text("Add Patient")) {
             Form {
-                TextField("환자등록번호", text: $state.patientNumber)
-                TextField("이름", text: $state.name)
-                Picker("성별", selection: $state.selectedGender) {
-                    Text("남성").tag(Gender.male)
-                    Text("여성").tag(Gender.female)
+                TextField("Patient Number", text: $state.patientNumber)
+                TextField("name", text: $state.name)
+                Picker("gender", selection: $state.selectedGender) {
+                    Text("male").tag(Gender.male)
+                    Text("female").tag(Gender.female)
                 }
                 .pickerStyle(.segmented)
                 HStack {
                     DatePicker(
-                        "출생날짜",
+                        "Birth Date",
                         selection: $state.birthDate,
                         displayedComponents: [.date]
                     )
                     .environment(\.locale, Locale(identifier: "ko_KR"))
-                    Text("\(state.age)세")
+                    Text("Age \(state.age)")
                 }
             }
         }
@@ -42,10 +42,10 @@ struct PatientInputView: View {
             .padding(.horizontal)
         
         HStack {
-            Button("취소") {
+            Button("Cancel") {
                 isPresentingPatientInput = false
             }
-            Button("저장") {
+            Button("Save") {
                 if state.isValid {
                     Task {
                         await onSave()

--- a/Hippo/Features/Mac/UI/Root/MacNavigationState.swift
+++ b/Hippo/Features/Mac/UI/Root/MacNavigationState.swift
@@ -6,6 +6,9 @@ import SwiftUI
 public struct MacNavigationState {
     /// 현재 선택된 환자 ID
     public var selectedPatientID: String?
+    
+    /// 현재 선택된 수술 ID
+    public var selectedOperationID: String?
 
     /// 오늘의 수술 화면 표시 여부
     public var isTodaysSurgerySelected: Bool = true
@@ -18,9 +21,15 @@ public struct MacNavigationState {
 
     /// 환자 입력 모드 (생성/수정)
     public var patientInputMode: PatientInputMode = .create
+    
+    /// 수술 입력 모드 (생성/수정)
+    public var operationInputMode: OperationInputMode = .create
 
     /// 수정할 환자 정보 (수정 모드일 때)
     public var patientToEdit: PatientDisplayModel?
+    
+    /// 수정할 수술 정보 (수정 모드일 때)
+    public var operationToEdit: OperationDisplayModel?
 
     public init() {}
 
@@ -52,6 +61,15 @@ public struct MacNavigationState {
 
     /// 수술 생성 시트 열기
     public mutating func openOperationCreateSheet() {
+        operationInputMode = .create
+        operationToEdit = nil
+        isPresentingOperationInput = true
+    }
+    
+    /// 수술 수정 시트 열기. 추가됨
+    public mutating func openOperationEditSheet(operation: OperationDisplayModel) {
+        operationInputMode = .edit
+        operationToEdit = operation
         isPresentingOperationInput = true
     }
 
@@ -67,9 +85,17 @@ public struct MacNavigationState {
     }
 }
 
-// MARK: - PatientInputMode
+extension MacNavigationState {
+
+}
+// MARK: - Patient&Operation InputMode
 
 public enum PatientInputMode {
+    case create
+    case edit
+}
+
+public enum OperationInputMode {
     case create
     case edit
 }

--- a/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
+++ b/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
@@ -23,9 +23,6 @@ public final class MacRootViewModel {
 
     /// 수술 입력 폼 상태
     public var operationInputState = OperationInputState()
-    
-    ///
-    
 
     // MARK: - Shared ViewModels (비즈니스 로직)
 
@@ -33,13 +30,16 @@ public final class MacRootViewModel {
     public let homeViewModel: HomeViewModel
 
     /// Operation ViewModel (Shared 재사용)
-    public var operationViewModel: OperationViewModel?
+    public var operationViewModel: OperationViewModel
 
     // MARK: - Initialization
 
     public init() {
         self.homeViewModel = HomeViewModel()
-        logger.debug("MacRootViewModel initialized with Shared ViewModels")
+        logger.debug("MacRootViewModel initialized with Shared HomeViewModels")
+        
+        self.operationViewModel = OperationViewModel()
+        logger.debug("MacRootViewModel initialized with Shared OperationViewModels")
     }
 
     // MARK: - Navigation Actions
@@ -82,6 +82,17 @@ public final class MacRootViewModel {
         navigationState.openOperationCreateSheet()
         operationInputState.reset()
         logger.debug("Opening operation create sheet for patient: \(patientID)")
+    }
+    
+    /// 수술 수정 시트 열기
+    public func openOperationEditSheet(operation: OperationDisplayModel) {
+        guard let patientID = navigationState.selectedPatientID else {
+            logger.warning("Cannot open operation sheet: no patient selected")
+            return
+        }
+        navigationState.openOperationEditSheet(operation: operation)
+        operationInputState = OperationInputState(from: operation)
+        logger.debug("Opening operation edit sheet for patient: \(patientID)")
     }
 
     /// 환자 입력 시트 닫기
@@ -185,6 +196,40 @@ public final class MacRootViewModel {
         } else {
             operationInputState.errorMessage = homeViewModel.state.alert
             logger.error("Failed to create operation")
+            return false
+        }
+    }
+    
+    /// 수술 수정. 추가됨.
+    public func updateOperation() async -> Bool {
+        guard let patientID = navigationState.selectedPatientID else {
+            logger.error("Cannot update operation: no patient selected")
+            return false
+        }
+        
+        guard let operationID = navigationState.selectedOperationID else {
+            logger.error("Cannot update operation: no operation selected")
+            return false
+        }
+        
+        await operationViewModel.updateOperation(
+            patientID: patientID,
+            operationID: operationID,
+            title: operationInputState.title,
+            diagnosis: operationInputState.diagnosis,
+            surgeon: operationInputState.surgeon,
+            surgicalSite: operationInputState.surgicalSite,
+            date: operationInputState.operationDate,
+            details: operationInputState.details
+        )
+        
+        if operationViewModel.state.alert == nil {
+            closeOperationInputSheet()
+            logger.debug("Operation updated successfully")
+            return true
+        } else {
+            operationInputState.errorMessage = operationViewModel.state.alert
+            logger.error("Failed to update operation")
             return false
         }
     }

--- a/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
+++ b/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
@@ -226,6 +226,7 @@ public final class MacRootViewModel {
         if operationViewModel.state.alert == nil {
             closeOperationInputSheet()
             logger.debug("Operation updated successfully")
+            await load()
             return true
         } else {
             operationInputState.errorMessage = operationViewModel.state.alert

--- a/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
+++ b/Hippo/Features/Mac/UI/Root/MacRootViewModel.swift
@@ -23,6 +23,9 @@ public final class MacRootViewModel {
 
     /// 수술 입력 폼 상태
     public var operationInputState = OperationInputState()
+    
+    ///
+    
 
     // MARK: - Shared ViewModels (비즈니스 로직)
 

--- a/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
+++ b/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
@@ -18,11 +18,11 @@ struct TodaysSurgeryView: View {
         return OperationListView(
             operations: operations,
             onEdit: { operationID in
-                if let op = operations.first(where: { $0.id == operationID }) {
-                    let patientId = op.patientId
-                    Task {
-                        
-                    }
+                viewModel.selectedOperationID = operationID
+                viewModel.selectedPatientID = viewModel.patientID(for: operationID)
+                
+                if let op = viewModel.operation(by: operationID) {
+                    viewModel.openOperationEditSheet(operation: op)
                 }
             },
             onDelete: { operationID in

--- a/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
+++ b/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
@@ -12,22 +12,25 @@ struct TodaysSurgeryView: View {
     let viewModel: TodaysSurgeryViewModel
 
     var body: some View {
-        
-        // 오늘 날짜(자정 기준) 범위 계산
-        let calendar = Calendar.current
-        let now = Date()
-        let startOfToday = calendar.startOfDay(for: now)
-        let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday)!
 
-        // 오늘에 해당하는 수술만 필터링
-//        let todaysOperations = OperationMockDataModel.patientOperationSamples
-//            .filter { $0.date >= startOfToday && $0.date < startOfTomorrow }
-//            .sorted { $0.date < $1.date }
-        
-        let operations = viewModel.todayOperations.map { $0.operation }
+        let operations = viewModel.operationCards
 
-        return OperationListView(operations: operations, onDelete: { _ in })
+        return OperationListView(
+            operations: operations,
+            onEdit: { operationID in
+                
+            },
+            onDelete: { operationID in
+                if let op = operations.first(where: { $0.id == operationID }) {
+                    let patientId = op.patientId
+                    Task {
+                        await viewModel.deleteOperationCard(operationID, in: patientId)
+                    }
+                }
+            }
+        )
     }
+
 }
 
 #Preview {

--- a/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
+++ b/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryView.swift
@@ -18,7 +18,12 @@ struct TodaysSurgeryView: View {
         return OperationListView(
             operations: operations,
             onEdit: { operationID in
-                
+                if let op = operations.first(where: { $0.id == operationID }) {
+                    let patientId = op.patientId
+                    Task {
+                        
+                    }
+                }
             },
             onDelete: { operationID in
                 if let op = operations.first(where: { $0.id == operationID }) {

--- a/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryViewModel.swift
+++ b/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryViewModel.swift
@@ -18,9 +18,10 @@ public final class TodaysSurgeryViewModel {
     public init(rootVM: MacRootViewModel) {
         self.rootVM = rootVM
     }
+    
+    public var operationCardDisplayModel = OperationCardDisplayModel()
 
     // MARK: - Computed Properties (rootVM 재사용)
-
     /// 오늘의 수술 목록
     public var todayOperations: [(patient: PatientDisplayModel, operation: OperationDisplayModel)] {
         rootVM.homeViewModel.todayOperations
@@ -38,8 +39,40 @@ public final class TodaysSurgeryViewModel {
 
     // MARK: - Actions (rootVM 위임)
 
+    /// 수술 삭제
+    public func deleteOperation(_ operationID: String) async {
+        await rootVM.deleteOperation(operationID: operationID)
+    }
+    
     /// 데이터 새로고침
     public func refresh() async {
         await rootVM.load()
+    }
+}
+
+extension TodaysSurgeryViewModel {
+    public var operationCards: [OperationCardDisplayModel] {
+        todayOperations.map { pair in
+            let patient = pair.patient
+            let op = pair.operation
+            return OperationCardDisplayModel(
+                id: op.id,
+                patientId: patient.id,
+                name: patient.name,
+                gender: patient.genderText,
+                birthDate: patient.birthDate,
+                title: op.title,
+                diagnosis: op.diagnosis,
+                surgeon: op.surgeon,
+                surgicalSite: op.surgicalSite,
+                operationDate: op.date,
+                details: op.details,
+                assets: op.assets
+            )
+        }
+    }
+    
+    public func deleteOperationCard(_ operationID: String, in patientID: String) async {
+        await rootVM.homeViewModel.removeOperation(operationID: operationID, fromPatientID: patientID)
     }
 }

--- a/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryViewModel.swift
+++ b/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryViewModel.swift
@@ -24,6 +24,18 @@ public final class TodaysSurgeryViewModel {
     public var todayOperations: [(patient: PatientDisplayModel, operation: OperationDisplayModel)] {
         rootVM.homeViewModel.todayOperations
     }
+    
+    /// 선택된 환자
+    public var selectedPatientID: String? {
+        get { rootVM.navigationState.selectedPatientID }
+        set { rootVM.navigationState.selectedPatientID = newValue }
+    }
+    
+    /// 선택된 수술
+    public var selectedOperationID: String? {
+        get { rootVM.navigationState.selectedOperationID }
+        set { rootVM.navigationState.selectedOperationID = newValue }
+    }
 
     /// 로딩 상태
     public var isLoading: Bool {
@@ -70,14 +82,18 @@ extension TodaysSurgeryViewModel {
         }
     }
     
-    /// 수술 카드 수정
-    public func updateOperationCard(_ operationID: String, in patientID: String) async {
-        await rootVM.operationViewModel.updateOperation()
+    /// 수술 카드 수정 시트 열기
+    public func openOperationEditSheet(operation: OperationDisplayModel) {
+        rootVM.openOperationEditSheet(operation: operation)
     }
     
-    /// 수술 카드 수정 시트 열기
-    public func openOperationEditSheet(operation: OperationDisplayModel) async {
-        rootVM.openOperationEditSheet(operation: operation)
+    /// 하위 뷰로부터 받은 ID 기반으로 수술 조회. 추가됨
+    public func operation(by id: String) -> OperationDisplayModel? {
+        todayOperations.first { $0.operation.id == id }?.operation
+    }
+    
+    public func patientID(for operationID: String) -> String? {
+        todayOperations.first { $0.operation.id == operationID }?.patient.id
     }
     
     /// 수술 카드 삭제

--- a/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryViewModel.swift
+++ b/Hippo/Features/Mac/UI/TodaysSurgery/TodaysSurgeryViewModel.swift
@@ -18,8 +18,6 @@ public final class TodaysSurgeryViewModel {
     public init(rootVM: MacRootViewModel) {
         self.rootVM = rootVM
     }
-    
-    public var operationCardDisplayModel = OperationCardDisplayModel()
 
     // MARK: - Computed Properties (rootVM 재사용)
     /// 오늘의 수술 목록
@@ -38,7 +36,7 @@ public final class TodaysSurgeryViewModel {
     }
 
     // MARK: - Actions (rootVM 위임)
-
+    
     /// 수술 삭제
     public func deleteOperation(_ operationID: String) async {
         await rootVM.deleteOperation(operationID: operationID)
@@ -72,6 +70,17 @@ extension TodaysSurgeryViewModel {
         }
     }
     
+    /// 수술 카드 수정
+    public func updateOperationCard(_ operationID: String, in patientID: String) async {
+        await rootVM.operationViewModel.updateOperation()
+    }
+    
+    /// 수술 카드 수정 시트 열기
+    public func openOperationEditSheet(operation: OperationDisplayModel) async {
+        rootVM.openOperationEditSheet(operation: operation)
+    }
+    
+    /// 수술 카드 삭제
     public func deleteOperationCard(_ operationID: String, in patientID: String) async {
         await rootVM.homeViewModel.removeOperation(operationID: operationID, fromPatientID: patientID)
     }

--- a/Hippo/Shared/Presentation/Home/OperationViewModel.swift
+++ b/Hippo/Shared/Presentation/Home/OperationViewModel.swift
@@ -234,6 +234,46 @@ public final class OperationViewModel {
             _state.alert = "Failed to update operation: \(error.localizedDescription)"
         }
     }
+    
+    public func updateOperation(
+        patientID: String,
+        operationID: String,
+        title: String,
+        diagnosis: String,
+        surgeon: String,
+        surgicalSite: String,
+        date: Date,
+        details: String) async {
+        do {
+            logger.debug("Attempting to update operation with ID \(operationID) for patient ID \(patientID)")
+            
+            let command = try UpdateOperationCommand(
+                operationID: operationID,
+                title: title,
+                diagnosis: diagnosis,
+                surgeon: surgeon,
+                surgicalSite: surgicalSite,
+                date: date,
+                details: details,
+            )
+
+            try await upsertOperation.run(
+                UpsertOperation.Input(patientID: patientID, command: command)
+            )
+            
+            // Reload operation from DB to update state
+            let updatedOperation = try await getOperation.run(
+                GetOperation.Input(patientID: patientID, operationID: operationID)
+            )
+            _state.operation = updatedOperation.toDisplayModel()
+
+            logger.debug("Operation updated and state refreshed successfully.")
+        } catch let validationError as ValidationError {
+            _state.alert = validationError.localizedDescription
+        } catch {
+            _state.alert = "Failed to update operation: \(error.localizedDescription)"
+        }
+    }
 
     public func deleteOperation() async {
         do {


### PR DESCRIPTION


## 📕 Issue Number

Close #139 

## 📙 작업 내역

> 수술 카드 뷰를 위한 별도의 디스플레이 모델을 추가하였습니다.
오늘의 수술 뷰에서 수술 카드 삭제 기능 구현을 위해 TodaysSurgeryViewModel에 extension으로 deleteOperationCard 메서드를 추가하였습니다.


-  수술 수정 기능도 완료하였습니다. 하지만 글자 수가 길면 잘리는 현상이 있네요.... 어쨋든 되긴 됩니다....
실제 수정은 HomeView의 시트에서 이루어지고요. 시트 표시 조건과 인풋모드만 환자 디테일 뷰와 오늘의 수술 뷰에서 바꾸는 방식으로 구현하였습니다. 그리고 각각의 뷰모델에 선택된 환자 id와 수술 id에 대한 값도 추가하였습니다. rootViewModel은 이들 값을 소유하고 있고요. 그래서 rootVM이 소유한 환자 id와 수술 id가 있기 때문에 rootVM에서는 별도의 매개변수 없이 updateOperation을 호출할 수 있습니다.

-> OperationViewModel에 매개변수 받는 버전 updateOperation( ... ) 추가하였습니다.
-> MacRootViewModel에서 수술 수정도 담당합니다.
-> 하위 viewModel들은 수술 시트 트리거만 담당합니다.

- [x] 작업 내역 작성


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

https://github.com/user-attachments/assets/260db230-f2cc-4238-aab2-1e8843ceee3b

https://github.com/user-attachments/assets/2683e0d9-cc4b-4490-bc47-770c5c45c123



## 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
HomeViewModel에 updateOperation 관련 메서드가 없습니다. 수정 기능을 위한 뷰모델 기능 정리가 필요해 보입니다.
-> OperationViewModel에 매개변수 받는 버전 updateOperation( ... ) 추가하였습니다.
-> MacRootViewModel에서 수술 수정도 담당합니다.


- 특이 사항 2

<br><br>
