### PR TITLE
Fix: EndoscopicStreamView 레이어 문제

### DIFF
--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeStreamView.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeStreamView.swift
@@ -176,6 +176,7 @@ struct VideoPlayerStereoView: View {
                 }
             }
         }
+        .frame(depth: 0)
         .onAppear {
             print("✅ VideoPlayerStereoView appeared, stereoRenderer status: \(receiver.stereoRenderer.status.rawValue)")
         }
@@ -201,6 +202,7 @@ struct StereoVideoView: View {
             // Setup the stereo video scene with left/right planes
             renderer.setupScene(in: content)
         }
+        .frame(depth: 0)
         #else
         Color.black
             .overlay(


### PR DESCRIPTION
RealityView에서는 .frame(depth: 0)으로 Z값 조절을 합니다.
애먼 ZStack 괴롭히지 맙시다
```
RealtiyView { content in
...
}
.frame(depth: 0)
```

## 📕 Issue Number

Close #161 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 작성


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

- 스크린 샷
<img width="1351" height="861" alt="스크린샷 2025-11-16 01 09 29" src="https://github.com/user-attachments/assets/973b27b7-c3ab-4f9e-9908-161c848cdd53" />
<img width="1351" height="861" alt="스크린샷 2025-11-16 01 09 34" src="https://github.com/user-attachments/assets/2c054f09-466b-4e8c-b3d4-c968d20f6b9a" />

### 어 왔어?
https://github.com/user-attachments/assets/3dce48d9-0a26-4806-8c80-731c7ec501c5


## 📘 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br><br>
