### PR TITLE
[Fix] #172 : Operation Update 중 Asset 처리 버그 수정

### DIFF
--- a/Hippo/Features/Vision/Runtime/ImmersiveSceneRuntime.swift
+++ b/Hippo/Features/Vision/Runtime/ImmersiveSceneRuntime.swift
@@ -1,33 +1,34 @@
 
 
+import Foundation
 import os.log
 import RealityKit
 import SwiftUI
-import Foundation
 
 @MainActor
 @Observable
 final class ImmersiveSceneRuntime {
     // MARK: - Logger
-    
+
     private let logger = Logger(subsystem: "com.television.hippo", category: "ImmersiveSceneRuntime")
-    
+
     public init() {}
-    
+
     // MARK: - State
 
     private var topAnchor: AnchorEntity?
-    
-    //MARK: - 3D model 들이 추가될 루트 엔티티
+
+    // MARK: - 3D model 들이 추가될 루트 엔티티
+
     var sceneRoot: Entity?
-    
+
     // MARK: - Setup
-    
-    var selectedEntity: Entity? = nil
-    private var eventSubscription: EventSubscription? = nil
-    
-    private let placementService: EntityPlacementService = EntityPlacementService()
-    
+
+    var selectedEntity: Entity?
+    private var eventSubscription: EventSubscription?
+
+    private let placementService: EntityPlacementService = .init()
+
     // RealityView 의 content 관리
     func setupScene(in content: RealityViewContent, attachments: RealityViewAttachments) {
         let anchor1 = AnchorEntity(.head)
@@ -40,22 +41,22 @@ final class ImmersiveSceneRuntime {
 
         // Test voice button (bottom-left corner, for testing only)
         if let testButton = attachments.entity(for: AttachmentIDs.testVoiceButton) {
-            testButton.position = [-0.4, -0.2, 0]  // Bottom-left, less intrusive
+            testButton.position = [-0.4, -0.2, 0] // Bottom-left, less intrusive
             anchor1.addChild(testButton)
         }
 
         content.add(anchor1)
 
         topAnchor = anchor1
-        
+
         // 3D 모델들의 월드 앵커의 부모
         let rootEntity = Entity()
         rootEntity.name = "SceneRoot"
         content.add(rootEntity)
-        self.sceneRoot = rootEntity
+        sceneRoot = rootEntity
 
         // 마지막 조작 Entity 정보 저장
-        eventSubscription = content.subscribe(to: ManipulationEvents.WillBegin.self)  { event in
+        eventSubscription = content.subscribe(to: ManipulationEvents.WillBegin.self) { event in
             if let previousSelection = self.selectedEntity {
                 previousSelection.name = ""
             }
@@ -65,14 +66,14 @@ final class ImmersiveSceneRuntime {
     }
 
     func placeEntity(url: URL) async {
-        guard let sceneRoot = self.sceneRoot else {
+        guard let sceneRoot = sceneRoot else {
             logger.error("Scene root is not yet set up.")
             return
         }
-        
+
         let anchor = placementService.placeAnchorInFront()
         sceneRoot.addChild(anchor)
-        
+
         do {
             selectedEntity = try await placementService.attach(url: url, to: anchor)
             logger.debug("Entity from URL '\(url.lastPathComponent)' placed successfully.")
@@ -82,28 +83,28 @@ final class ImmersiveSceneRuntime {
             anchor.removeFromParent()
         }
     }
-    
+
     func deleteSelectedEntity() async {
         guard let entity = selectedEntity else {
             logger.warning("Delete requested, but no entity is selected.")
             return
         }
-        
+
         await placementService.detach(entity: entity)
-        self.selectedEntity = nil
-        
+        selectedEntity = nil
+
         logger.debug("Selected entity deleted and selection cleared.")
     }
-    
+
     func start() {
         logger.debug("🐛 ImmersiveSceneRuntime started")
         ARSessionController.shared.runARSession()
     }
-    
+
     func stop() {
         logger.debug("🐛 ImmersiveSceneRuntime stopped")
         topAnchor = nil
-        
+
         // 제스쳐 이벤트 구독 정리
         eventSubscription?.cancel()
     }

--- a/Hippo/Features/Vision/UI/Operation/Components/Molecules/ModeFilelListView.swift
+++ b/Hippo/Features/Vision/UI/Operation/Components/Molecules/ModeFilelListView.swift
@@ -14,6 +14,7 @@ struct ModelFileListView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(OperationViewModel.self) private var viewModel
     let assets: [OperationAssetDisplayModel]
+    let isReadOnly: Bool
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -23,6 +24,7 @@ struct ModelFileListView: View {
                 ForEach(assets, id: \.self.id) { asset in
                     ModelPreviewCard(
                         asset: asset,
+                        isReadOnly: isReadOnly,
                         isSelected: viewModel.state.selectedAssetID == asset.id,
                         onSelect: {
                             withAnimation(.easeInOut(duration: 0.2)) {
@@ -45,7 +47,7 @@ struct ModelFileListView: View {
 }
 
 #Preview {
-    ModelFileListView(assets: [])
+    ModelFileListView(assets: [], isReadOnly: true)
         .frame(height: 150)
         .background(.thinMaterial)
 }

--- a/Hippo/Features/Vision/UI/Operation/Components/Molecules/ModelPreviewCard.swift
+++ b/Hippo/Features/Vision/UI/Operation/Components/Molecules/ModelPreviewCard.swift
@@ -7,15 +7,16 @@
 
 // Hippo/Features/Vision/UI/Operation/Components/Molecules/Model3DPreviewCard.swift
 
+import os.log
 import QuickLookThumbnailing
 import RealityKit
 import SwiftUI
-import os.log
 
 /// 3D 모델 파일을 미리보기로 표시하는 Molecule 컴포넌트
 struct ModelPreviewCard: View {
     let asset: OperationAssetDisplayModel
     let size: CGFloat
+    let isReadOnly: Bool
     let isSelected: Bool
     let onSelect: () -> Void
     let onDelete: () -> Void
@@ -23,12 +24,14 @@ struct ModelPreviewCard: View {
     init(
         asset: OperationAssetDisplayModel,
         size: CGFloat = 130,
+        isReadOnly: Bool = true,
         isSelected: Bool,
         onSelect: @escaping () -> Void,
         onDelete: @escaping () -> Void
     ) {
         self.asset = asset
         self.size = size
+        self.isReadOnly = isReadOnly
         self.isSelected = isSelected
         self.onSelect = onSelect
         self.onDelete = onDelete
@@ -55,19 +58,20 @@ struct ModelPreviewCard: View {
                         .frame(width: size, height: size)
                 }
 
-                // 삭제 오버레이
-                if isSelected {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(.hippoBlack)
-                        .frame(width: size, height: size)
+                if !isReadOnly {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.hippoBlack)
+                            .frame(width: size, height: size)
 
-                    Image(systemName: "trash.fill")
-                        .font(.system(size: 40))
-                        .foregroundStyle(.white)
+                        Image(systemName: "trash.fill")
+                            .font(.system(size: 40))
+                            .foregroundStyle(.white)
+                    }
                 }
             }
         }
-        .onTapGesture { handleTap() }
+        .onTapGesture { isReadOnly ? nil : handleTap() }
         .task {
             await generateThumbnail()
         }
@@ -100,7 +104,7 @@ struct ModelPreviewCard: View {
     }
 }
 
- #Preview {
+#Preview {
     ModelPreviewCard(
         asset: OperationAssetDisplayModel(id: "", fileName: "", createdAt: Date(), fileURL: URL(string: "")!),
         isSelected: false,
@@ -108,4 +112,4 @@ struct ModelPreviewCard: View {
         onDelete: {}
     )
     .padding()
- }
+}

--- a/Hippo/Features/Vision/UI/Operation/Components/Organisms/DetailHeader.swift
+++ b/Hippo/Features/Vision/UI/Operation/Components/Organisms/DetailHeader.swift
@@ -32,16 +32,25 @@ struct DetailHeader: View {
                 .help(operation.assets.isEmpty ? "No Video" : "Video")
 
                 Menu {
-                    Button("수술 완료") {
-                        Task {
-                            await viewModel.updateOperationStatus(to: .completed)
-                            appModel.refreshUI()
+                    if viewModel.state.operation?.status == .planned {
+                        Button("수술 완료하기") {
+                            Task {
+                                await viewModel.updateOperationStatus(to: .completed)
+                                appModel.refreshUI()
+                            }
+                        }
+                    } else {
+                        Button("수술 대기하기") {
+                            Task {
+                                await viewModel.updateOperationStatus(to: .planned)
+                                appModel.refreshUI()
+                            }
                         }
                     }
-                    Button("수술 편집") {
+                    Button("수술 편집하기") {
                         viewModel.isShowingEditInputView = true
                     }
-                    Button("수술 삭제", role: .destructive) {
+                    Button("수술 삭제하기", role: .destructive) {
                         Task {
                             await viewModel.deleteOperation()
                             appModel.refreshUI()

--- a/Hippo/Features/Vision/UI/Operation/Components/Organisms/FileAttachmentSection.swift
+++ b/Hippo/Features/Vision/UI/Operation/Components/Organisms/FileAttachmentSection.swift
@@ -20,7 +20,7 @@ struct FileAttachmentSection: View {
                 if selectedAssets.isEmpty {
                     FileAttachmentPlaceholder()
                 } else {
-                    ModelFileListView(assets: selectedAssets.map { $0.toDisplayModel() })
+                    ModelFileListView(assets: selectedAssets.map { $0.toDisplayModel() }, isReadOnly: false)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: 150)

--- a/Hippo/Features/Vision/UI/Operation/OperationDetailView.swift
+++ b/Hippo/Features/Vision/UI/Operation/OperationDetailView.swift
@@ -34,7 +34,7 @@ struct OperationDetailView: View {
                                     .foregroundStyle(.primary)
 
                                 // 모델 이미지
-                                ModelFileListView(assets: operation.assets)
+                                ModelFileListView(assets: operation.assets, isReadOnly: true)
 
                                 // 수술 상세 정보
                                 DetailSubPart(

--- a/Hippo/Features/Vision/UI/Operation/Recording/RecordingViewModel.swift
+++ b/Hippo/Features/Vision/UI/Operation/Recording/RecordingViewModel.swift
@@ -15,13 +15,13 @@ import SwiftUI
 class RecordingViewModel {
     /// The scene used to present the video.
     var scene: UIScene?
-    
+
     var recordings: [OperationRecording] = []
 
     /// An object that controls the playback of a video.
-    private let player = AVPlayer()
+    var player = AVPlayer()
     /// An object that provides the playback user interface.
-    private var playerViewController: AVPlayerViewController?
+    var playerViewController: AVPlayerViewController?
 
     /// Creates a player model.
     init() {
@@ -50,7 +50,7 @@ class RecordingViewModel {
             // videoData를 디스크에 임시 파일로 쓰기
             try record.videoData.write(to: tempURL, options: .atomic)
 
-            let player = AVPlayer(url: tempURL)
+            player = AVPlayer(url: tempURL)
         } catch {
             print("Error writing temporary video file: \(error.localizedDescription)")
         }
@@ -149,7 +149,7 @@ class RecordingViewModel {
 
     // -------------------------------------------------------
 //
-    
+
 //    var selectedRecording: OperationRecording?
 //
 //    var sortedRecordings: [OperationRecording] {

--- a/Hippo/Shared/Presentation/Home/OperationViewModel.swift
+++ b/Hippo/Shared/Presentation/Home/OperationViewModel.swift
@@ -42,7 +42,7 @@ public final class OperationViewModel {
 
     private let _state = OperationState()
     public var state: OperationState { _state } // 읽기 전용, 관찰 가능
-    
+
     public var path = NavigationPath()
 
     // MARK: - UI State (Accessible)
@@ -180,21 +180,9 @@ public final class OperationViewModel {
         state.selectedAssetID = id
     }
 
-    public func deleteModelAsset(_ id: String) async {
-        do {
-            if let patientID = state.patient?.id, let operationID = state.operation?.id {
-                try await removeAssetFromOperation.run(
-                    RemoveAssetFromOperation.Input(
-                        patientID: patientID,
-                        operationID: operationID,
-                        assetID: id
-                    )
-                )
-            }
-            state.selectedAssetID = nil
-        } catch {
-            _state.alert = "Failed to remove asset: \(error.localizedDescription)"
-        }
+    public func deleteModelAsset(_: String) async {
+        operation3DAssets.removeAll { $0.id == state.selectedAssetID }
+        state.selectedAssetID = nil
     }
 
     public func updateOperation() async {
@@ -230,7 +218,7 @@ public final class OperationViewModel {
             _state.alert = "Failed to update operation: \(error.localizedDescription)"
         }
     }
-    
+
     public func updateOperation(
         patientID: String,
         operationID: String,
@@ -240,10 +228,11 @@ public final class OperationViewModel {
         surgicalSite: String,
         date: Date,
         details: String,
-        assets: [OperationAsset]) async {
+        assets: [OperationAsset]
+    ) async {
         do {
             logger.debug("Attempting to update operation with ID \(operationID) for patient ID \(patientID)")
-            
+
             let command = try UpdateOperationCommand(
                 operationID: operationID,
                 title: title,
@@ -258,7 +247,7 @@ public final class OperationViewModel {
             try await upsertOperation.run(
                 UpsertOperation.Input(patientID: patientID, command: command)
             )
-            
+
             // Reload operation from DB to update state
             let updatedOperation = try await getOperation.run(
                 GetOperation.Input(patientID: patientID, operationID: operationID)


### PR DESCRIPTION
## 📕 Issue Number

Close #172 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- 수술 Asset(3D 모델 등) 처리 중 발생하던 버그 수정: Operation 업데이트 중 asset 관리(추가/삭제/연결) 과정에서 누락되거나 오작동하던 부분을 안정적으로 수리.
- 수술디테일뷰에서 수술 완료하기 & 수술 대기하기 버튼 개선

## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

https://github.com/user-attachments/assets/ec1f622b-3345-4151-af58-a4333abdd3a5

https://github.com/user-attachments/assets/eec7a8d7-333c-49dc-a276-a16ea23ead0a


## 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 노아가 말한거 CRUD 쪽 클리어
- 특이 사항 2

<br><br>
