### PR TITLE
feat: #195 2D 영상 재생 모드 추가 및 기본값 설정

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -68,7 +68,6 @@
 		1476821E2ECF810D0065791C /* SyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1476821D2ECF81080065791C /* SyncMonitor.swift */; };
 		1476821F2ECF810D0065791C /* SyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1476821D2ECF81080065791C /* SyncMonitor.swift */; };
 		147682202ECF810D0065791C /* SyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1476821D2ECF81080065791C /* SyncMonitor.swift */; };
-		1476822E2ED3FA350065791C /* endoscope-demo.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 1476822D2ED3FA350065791C /* endoscope-demo.mp4 */; };
 		1479B8AB2ECAC9AE003397B0 /* AppleSpeechRecognitionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2523A6E22EC649A600842508 /* AppleSpeechRecognitionService.swift */; };
 		1479B8AD2ECB1134003397B0 /* RecordingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1479B8AC2ECB112D003397B0 /* RecordingViewModel.swift */; };
 		1479B8AE2ECB1134003397B0 /* RecordingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1479B8AC2ECB112D003397B0 /* RecordingViewModel.swift */; };
@@ -224,11 +223,18 @@
 		2523A6F32EC649A600842508 /* FallbackVoiceCommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2523A6DC2EC649A600842508 /* FallbackVoiceCommandParser.swift */; };
 		2523A6F52EC663DB00842508 /* ImmersiveSceneRuntime+VoiceControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2523A6F42EC663DB00842508 /* ImmersiveSceneRuntime+VoiceControl.swift */; };
 		2523A6F62EC663DB00842508 /* ImmersiveSceneRuntime+VoiceControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2523A6F42EC663DB00842508 /* ImmersiveSceneRuntime+VoiceControl.swift */; };
+		253207F02ED5785C000C2E72 /* endoscope-demo.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 253207EF2ED5785C000C2E72 /* endoscope-demo.mp4 */; };
+		253207F12ED5785C000C2E72 /* endoscope-demo.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 253207EF2ED5785C000C2E72 /* endoscope-demo.mp4 */; };
+		253207F22ED5785C000C2E72 /* endoscope-demo.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 253207EF2ED5785C000C2E72 /* endoscope-demo.mp4 */; };
+		253207F42ED5786D000C2E72 /* demo-2d.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 253207F32ED5786D000C2E72 /* demo-2d.mp4 */; };
+		253207F52ED5786D000C2E72 /* demo-2d.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 253207F32ED5786D000C2E72 /* demo-2d.mp4 */; };
+		253207F62ED5786D000C2E72 /* demo-2d.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 253207F32ED5786D000C2E72 /* demo-2d.mp4 */; };
 		253881C62ECA1DEE001442C9 /* EndoscopeRenderPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253881C52ECA1DEE001442C9 /* EndoscopeRenderPipeline.swift */; };
 		253881CB2ECA3C00001442C9 /* SplitSBSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253881C92ECA3C00001442C9 /* SplitSBSView.swift */; };
 		253881CC2ECA3C00001442C9 /* EndoscopeViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253881C72ECA3C00001442C9 /* EndoscopeViewMode.swift */; };
 		253881CD2ECA3C00001442C9 /* RawStreamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253881C82ECA3C00001442C9 /* RawStreamView.swift */; };
 		253881CE2ECA3C00001442C9 /* Stereo3DView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253881CA2ECA3C00001442C9 /* Stereo3DView.swift */; };
+		25DEMO2D012ED60000001442 /* FileDemo2DView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DEMO2D002ED60000001442 /* FileDemo2DView.swift */; };
 		253881D02ECB5FCD001442C9 /* StereoVideoPlayerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253881CF2ECB5FCD001442C9 /* StereoVideoPlayerHelper.swift */; };
 		2581FCE52EBBC6870059678D /* OperationInputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2581FCE42EBBC6870059678D /* OperationInputState.swift */; };
 		2581FCE92EBBC6FA0059678D /* MacNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2581FCE62EBBC6FA0059678D /* MacNavigationState.swift */; };
@@ -547,7 +553,6 @@
 		146F102A2EA3ACFD00DDDC35 /* HippoAssets */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HippoAssets; sourceTree = "<group>"; };
 		146F102E2EA3AF1000DDDC35 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		1476821D2ECF81080065791C /* SyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMonitor.swift; sourceTree = "<group>"; };
-		1476822D2ED3FA350065791C /* endoscope-demo.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "endoscope-demo.mp4"; sourceTree = "<group>"; };
 		1479B8AC2ECB112D003397B0 /* RecordingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingViewModel.swift; sourceTree = "<group>"; };
 		1479B8B02ECB3769003397B0 /* SceneProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneProvider.swift; sourceTree = "<group>"; };
 		1479B8B22ECB3D0B003397B0 /* RecordCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordCard.swift; sourceTree = "<group>"; };
@@ -641,11 +646,14 @@
 		2523A6E02EC649A600842508 /* VoiceControlDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceControlDependencies.swift; sourceTree = "<group>"; };
 		2523A6E22EC649A600842508 /* AppleSpeechRecognitionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSpeechRecognitionService.swift; sourceTree = "<group>"; };
 		2523A6F42EC663DB00842508 /* ImmersiveSceneRuntime+VoiceControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImmersiveSceneRuntime+VoiceControl.swift"; sourceTree = "<group>"; };
+		253207EF2ED5785C000C2E72 /* endoscope-demo.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "endoscope-demo.mp4"; sourceTree = "<group>"; };
+		253207F32ED5786D000C2E72 /* demo-2d.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "demo-2d.mp4"; sourceTree = "<group>"; };
 		253881C52ECA1DEE001442C9 /* EndoscopeRenderPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndoscopeRenderPipeline.swift; sourceTree = "<group>"; };
 		253881C72ECA3C00001442C9 /* EndoscopeViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndoscopeViewMode.swift; sourceTree = "<group>"; };
 		253881C82ECA3C00001442C9 /* RawStreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStreamView.swift; sourceTree = "<group>"; };
 		253881C92ECA3C00001442C9 /* SplitSBSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitSBSView.swift; sourceTree = "<group>"; };
 		253881CA2ECA3C00001442C9 /* Stereo3DView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stereo3DView.swift; sourceTree = "<group>"; };
+		25DEMO2D002ED60000001442 /* FileDemo2DView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDemo2DView.swift; sourceTree = "<group>"; };
 		253881CF2ECB5FCD001442C9 /* StereoVideoPlayerHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StereoVideoPlayerHelper.swift; sourceTree = "<group>"; };
 		2581FCE42EBBC6870059678D /* OperationInputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationInputState.swift; sourceTree = "<group>"; };
 		2581FCE62EBBC6FA0059678D /* MacNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacNavigationState.swift; sourceTree = "<group>"; };
@@ -1517,6 +1525,7 @@
 		25B5ADC62ED2DD05008F1261 /* ModeViews */ = {
 			isa = PBXGroup;
 			children = (
+				25DEMO2D002ED60000001442 /* FileDemo2DView.swift */,
 				253881C82ECA3C00001442C9 /* RawStreamView.swift */,
 				253881C92ECA3C00001442C9 /* SplitSBSView.swift */,
 				253881CA2ECA3C00001442C9 /* Stereo3DView.swift */,
@@ -1679,7 +1688,8 @@
 				14DE51512EB771420027D9A0 /* HIPPO.icon */,
 				C02FFA5A2E9FFF6F00F16742 /* MacAssets.xcassets */,
 				C02FFA5B2E9FFF6F00F16742 /* VisionAssets.xcassets */,
-				1476822D2ED3FA350065791C /* endoscope-demo.mp4 */,
+				253207EF2ED5785C000C2E72 /* endoscope-demo.mp4 */,
+				253207F32ED5786D000C2E72 /* demo-2d.mp4 */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2147,9 +2157,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				253207F02ED5785C000C2E72 /* endoscope-demo.mp4 in Resources */,
 				C02FFA932E9FFF6F00F16742 /* VisionAssets.xcassets in Resources */,
 				14DE51542EB771420027D9A0 /* HIPPO.icon in Resources */,
-				1476822E2ED3FA350065791C /* endoscope-demo.mp4 in Resources */,
+				253207F42ED5786D000C2E72 /* demo-2d.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2158,6 +2169,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				14DE51532EB771420027D9A0 /* HIPPO.icon in Resources */,
+				253207F22ED5785C000C2E72 /* endoscope-demo.mp4 in Resources */,
+				253207F52ED5786D000C2E72 /* demo-2d.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2165,8 +2178,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				253207F12ED5785C000C2E72 /* endoscope-demo.mp4 in Resources */,
 				C02FFA8D2E9FFF6F00F16742 /* MacAssets.xcassets in Resources */,
 				14DE51522EB771420027D9A0 /* HIPPO.icon in Resources */,
+				253207F62ED5786D000C2E72 /* demo-2d.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2366,6 +2381,7 @@
 				253881CC2ECA3C00001442C9 /* EndoscopeViewMode.swift in Sources */,
 				253881CD2ECA3C00001442C9 /* RawStreamView.swift in Sources */,
 				253881CE2ECA3C00001442C9 /* Stereo3DView.swift in Sources */,
+				25DEMO2D012ED60000001442 /* FileDemo2DView.swift in Sources */,
 				27AD7AC62EB4948A00E84809 /* LayerEyeButton.swift in Sources */,
 				C04678402EA00B4A00D160DA /* HomeViewModel.swift in Sources */,
 				1442546A2EAAC61F00583CC3 /* WindowIDs.swift in Sources */,

--- a/Hippo/Applications/VisionApp/HippoVisionApp.swift
+++ b/Hippo/Applications/VisionApp/HippoVisionApp.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 @main
 struct HippoVisionApp: App {
-    @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate
-
     @State private var appModel = AppModel()
     @State private var homeViewModel = HomeViewModel()
 

--- a/Hippo/Features/Vision/Endoscope/Streaming/Renderer/EndoscopeRenderPipeline.swift
+++ b/Hippo/Features/Vision/Endoscope/Streaming/Renderer/EndoscopeRenderPipeline.swift
@@ -240,6 +240,14 @@ public final class EndoscopeRenderPipeline: ObservableObject {
             logger.warning("⚠️ processFrame called in fileDemo mode - this should not happen")
             logger.warning("   File demo uses enqueue(sampleBuffer:) instead")
             return
+
+        case .fileDemo2D:
+            // 2D File demo mode does not use the pipeline at all
+            // FileDemo2DView handles playback directly via AVPlayer + VideoMaterial
+            // This case should never be reached in normal operation
+            logger.warning("⚠️ processFrame called in fileDemo2D mode - this should not happen")
+            logger.warning("   2D demo uses AVPlayer directly, not the render pipeline")
+            return
         }
 
         // Log periodically

--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/Components/PrimaryModeToggle.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/Components/PrimaryModeToggle.swift
@@ -2,15 +2,16 @@
 //  PrimaryModeToggle.swift
 //  Hippo
 //
-//  Primary mode toggle: WebRTC vs Demo
+//  Primary mode toggle: WebRTC vs Demo (2D/3D)
 //  Handles top-level mode switching with proper resource cleanup
 //
 
 import SwiftUI
 
-/// 1차 모드 토글: WebRTC 스트림 vs 3D Demo
+/// 1차 모드 토글: WebRTC 스트림 vs Demo (2D/3D)
 /// - Demo → WebRTC: stopAll() → switchMode() → connect()
-/// - WebRTC → Demo: stopAll() → configure(.fileDemo) → update UI
+/// - WebRTC → Demo: stopAll() → configure(.fileDemo/.fileDemo2D) → update UI
+/// - 2D Demo ↔ 3D Demo: UI 상태만 전환 (같은 Demo 모드 내 전환)
 struct PrimaryModeToggle: View {
     @ObservedObject var uiState: StreamUIState
     @ObservedObject var viewModel: EndoscopeStreamViewModel
@@ -43,7 +44,7 @@ struct PrimaryModeToggle: View {
                 HStack(spacing: 6) {
                     Image(systemName: "antenna.radiowaves.left.and.right")
                         .font(.system(size: 11))
-                    Text("WebRTC 스트림")
+                    Text("WebRTC")
                         .font(.system(size: 12, weight: .semibold))
                 }
                 .padding(.horizontal, 12)
@@ -68,30 +69,80 @@ struct PrimaryModeToggle: View {
             .hoverEffect()
             .disabled(uiState.isSwitching)
 
+            // 2D Demo 버튼
+            Button {
+                Task { @MainActor in
+                    // 이미 2D Demo면 무시
+                    guard !uiState.activeMode.is2DDemo else { return }
+
+                    print("🔄 [PrimaryModeToggle] Switching to 2D Demo")
+
+                    if uiState.activeMode.isWebRTCMode {
+                        // WebRTC → 2D Demo
+                        viewModel.stopAll()
+                    }
+
+                    // 2D Demo는 파이프라인 설정 불필요 (AVPlayer 직접 사용)
+                    // UI 상태만 변경하면 FileDemo2DView가 자체적으로 처리
+                    uiState.activeMode = .fileDemo2D
+
+                    print("✅ [PrimaryModeToggle] 2D Demo mode ready")
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "play.rectangle.fill")
+                        .font(.system(size: 11))
+                    Text("2D Demo")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule().fill(
+                        uiState.activeMode.is2DDemo
+                        ? Color.blue.opacity(0.2)
+                        : Color.clear
+                    )
+                )
+                .overlay(
+                    Capsule().stroke(
+                        uiState.activeMode.is2DDemo
+                        ? Color.blue
+                        : Color.clear,
+                        lineWidth: 1
+                    )
+                )
+            }
+            .buttonStyle(.plain)
+            .hoverEffect()
+            .disabled(uiState.isSwitching)
+
             // 3D Demo 버튼
             Button {
                 Task { @MainActor in
-                    // WebRTC → Demo로 갈 때만 동작
-                    guard uiState.activeMode.isWebRTCMode else { return }
+                    // 이미 3D Demo면 무시
+                    guard !uiState.activeMode.is3DDemo else { return }
 
-                    print("🔄 [PrimaryModeToggle] WebRTC → Demo: Stopping WebRTC and configuring Demo")
+                    print("🔄 [PrimaryModeToggle] Switching to 3D Demo")
 
-                    // 1) WebRTC 완전 정리
-                    viewModel.stopAll()
+                    if uiState.activeMode.isWebRTCMode {
+                        // WebRTC → 3D Demo
+                        viewModel.stopAll()
+                    }
 
-                    // 2) CRITICAL: VideoPlayer를 먼저 생성 (UI 전환 전에!)
+                    // CRITICAL: VideoPlayer를 먼저 생성 (UI 전환 전에!)
                     //    이렇게 해야 Stereo3DView가 생성될 때 이미 VideoPlayer가 준비됨
                     print("   Configuring pipeline for fileDemo mode...")
                     await viewModel.configure(for: .fileDemo)
 
-                    // 3) UI 상태를 Demo로 변경 (이제 VideoPlayer가 준비됨)
+                    // UI 상태를 3D Demo로 변경 (이제 VideoPlayer가 준비됨)
                     uiState.activeMode = .fileDemo
 
-                    print("✅ [PrimaryModeToggle] Demo mode ready")
+                    print("✅ [PrimaryModeToggle] 3D Demo mode ready")
                 }
             } label: {
                 HStack(spacing: 6) {
-                    Image(systemName: "play.circle.fill")
+                    Image(systemName: "cube.fill")
                         .font(.system(size: 11))
                     Text("3D Demo")
                         .font(.system(size: 12, weight: .semibold))
@@ -100,14 +151,14 @@ struct PrimaryModeToggle: View {
                 .padding(.vertical, 6)
                 .background(
                     Capsule().fill(
-                        uiState.activeMode.isDemoMode
+                        uiState.activeMode.is3DDemo
                         ? Color.blue.opacity(0.2)
                         : Color.clear
                     )
                 )
                 .overlay(
                     Capsule().stroke(
-                        uiState.activeMode.isDemoMode
+                        uiState.activeMode.is3DDemo
                         ? Color.blue
                         : Color.clear,
                         lineWidth: 1

--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/Components/WebRTCSubModeToggle.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/Components/WebRTCSubModeToggle.swift
@@ -55,7 +55,8 @@ struct WebRTCSubModeToggle: View {
         case .rawStream: return "원본 스트림"
         case .splitSBS:  return "좌우 분할"
         case .stereo3D:  return "3D 보기"
-        case .fileDemo:  return "Demo"  // Should not be visible
+        case .fileDemo:  return "3D Demo"    // Should not be visible
+        case .fileDemo2D: return "2D Demo"   // Should not be visible
         }
     }
 
@@ -64,7 +65,8 @@ struct WebRTCSubModeToggle: View {
         case .rawStream: return "rectangle.on.rectangle"
         case .splitSBS:  return "square.split.2x1"
         case .stereo3D:  return "view.3d"
-        case .fileDemo:  return "play.circle"  // Should not be visible
+        case .fileDemo:  return "cube"              // Should not be visible
+        case .fileDemo2D: return "play.rectangle"   // Should not be visible
         }
     }
 }

--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeStreamView.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeStreamView.swift
@@ -53,6 +53,10 @@ struct EndoscopeStreamView: View {
                 // Main content - route based on activeMode (not viewMode)
                 Group {
                     switch uiState.activeMode {
+                    case .fileDemo2D:
+                        // 2D Demo: AVPlayer + VideoMaterial (no pipeline)
+                        FileDemo2DView()
+
                     case .rawStream:
                         RawStreamView(
                             receiver: receiver,
@@ -73,7 +77,7 @@ struct EndoscopeStreamView: View {
                         )
 
                     case .fileDemo:
-                        // Demo 모드도 Stereo3D 렌더링 재사용 (mode 명시)
+                        // 3D Demo 모드도 Stereo3D 렌더링 재사용 (mode 명시)
                         Stereo3DView(
                             receiver: receiver,
                             pipeline: receiver.renderPipeline,
@@ -122,7 +126,7 @@ struct EndoscopeStreamView: View {
             .onAppear {
                 // CRITICAL: Demo 모드는 외부에서 configure 호출하므로 여기서는 건너뜀
                 // Demo 모드는 EndoscopeStreamWindow에서 직접 관리됨
-                guard uiState.activeMode != .fileDemo else {
+                guard !uiState.activeMode.isDemoMode else {
                     print("⏭️ [EndoscopeStreamView] Skipping configure for Demo mode (handled externally)")
                     return
                 }
@@ -156,8 +160,8 @@ struct ViewModeToggle: View {
                     nextMode = .stereo3D
                 case .stereo3D:
                     nextMode = .rawStream
-                case .fileDemo:
-                    // Demo is not part of WebRTC cycle
+                case .fileDemo, .fileDemo2D:
+                    // Demo modes are not part of WebRTC cycle
                     // This should never happen (button is hidden in Demo mode)
                     print("⚠️ [ViewModeToggle] Toggle pressed in Demo mode - ignoring")
                     return

--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeStreamWindow.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeStreamWindow.swift
@@ -15,22 +15,22 @@ struct EndoscopeStreamWindow: View {
     @State private var showSettings = false
 
     // UI state for coordinated mode transitions (shared with view and control bar)
-    // 기본 모드: Demo (endoscope-demo.mp4 자동 재생)
-    @StateObject private var streamUIState = StreamUIState(initialMode: .fileDemo)
+    // 기본 모드: 2D Demo (demo-2d.mp4 자동 재생)
+    @StateObject private var streamUIState = StreamUIState(initialMode: .fileDemo2D)
 
     var body: some View {
         ZStack(alignment: .top) {
             // Main video view (uses shared uiState)
-            // CRITICAL: Show view if connected OR in Demo mode
+            // CRITICAL: Show view if connected OR in Demo mode (2D or 3D)
             EndoscopeStreamView(
                 receiver: viewModel.webRTCReceiver,
-                isVisible: viewModel.connectionStatus.isActive || streamUIState.activeMode == .fileDemo,
+                isVisible: viewModel.connectionStatus.isActive || streamUIState.activeMode.isDemoMode,
                 uiState: streamUIState
             )
             .frame(minWidth: 900, minHeight: 600)
 
             // Connection status overlay (Demo 모드가 아니고 connected 상태가 아닐 때만 표시)
-            if streamUIState.activeMode != .fileDemo && viewModel.connectionStatus != .connected {
+            if !streamUIState.activeMode.isDemoMode && viewModel.connectionStatus != .connected {
                 ConnectionOverlay(
                     status: viewModel.connectionStatus,
                     onSettingsPressed: {
@@ -40,8 +40,8 @@ struct EndoscopeStreamWindow: View {
                 .padding(.top, 40)
             }
 
-            // Top control bar overlay - visible when connected OR in demo mode
-            if viewModel.connectionStatus == .connected || viewModel.activeMode == .fileDemo {
+            // Top control bar overlay - visible when connected OR in demo mode (2D or 3D)
+            if viewModel.connectionStatus == .connected || streamUIState.activeMode.isDemoMode {
                 VStack {
                     HStack(spacing: 16) {
                         // Left: Primary mode toggle (WebRTC vs Demo)
@@ -93,22 +93,18 @@ struct EndoscopeStreamWindow: View {
             }
         }
         .task {
-            // 기본 모드: Demo (endoscope-demo.mp4 자동 재생)
-            // WebRTC 모드가 필요하면 상단 토글 버튼으로 전환 가능
+            // 기본 모드: 2D Demo (demo-2d.mp4 자동 재생)
+            // 2D Demo는 AVPlayer + VideoMaterial을 사용하므로 파이프라인 설정 불필요
+            // WebRTC 또는 3D Demo 모드가 필요하면 상단 토글 버튼으로 전환 가능
 
             // Setup Demo cleanup callback
             streamUIState.onExitDemoMode = { [weak viewModel] in
                 viewModel?.stopAll()
             }
 
-            // CRITICAL: 파이프라인을 먼저 구성해서 VideoPlayer를 생성
-            await viewModel.configure(for: .fileDemo)
-
-            // VideoPlayer 초기화 완료 대기 (100ms)
-            try? await Task.sleep(nanoseconds: 100_000_000)
-
-            // 그 다음 UI 모드를 Demo로 전환 → Stereo3DView가 VideoPlayer를 물고 appear
-            streamUIState.activeMode = .fileDemo
+            // 2D Demo는 FileDemo2DView가 자체적으로 AVPlayer를 관리하므로
+            // 파이프라인 설정 없이 바로 UI 모드만 설정
+            // (이미 initialMode: .fileDemo2D로 설정됨)
         }
         .onDisappear {
             Task {

--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeViewMode.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/EndoscopeViewMode.swift
@@ -11,11 +11,17 @@ import Foundation
 /// Endoscope streaming pipeline modes
 /// Progressive stages: Demo (file-based) → 1 (debug) → 2 (debug) → 3 (production)
 public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
-    /// Stage 0: File-based Demo (showcase mode) - FIRST
+    /// Stage 0-A: 2D File Demo (default showcase mode)
+    /// - Purpose: Simple 2D video playback without any processing
+    /// - Pipeline: File → AVPlayer → VideoMaterial → Plane Entity
+    /// - Usage: Default demo - Play local 2D file (demo-2d.mp4) as flat screen
+    case fileDemo2D = "2D Demo"
+
+    /// Stage 0-B: 3D File-based Demo (showcase mode)
     /// - Purpose: Demo 3D playback without WebRTC connection
     /// - Pipeline: File → SerialProcessor → Stereo Tagged CMSampleBuffer → VideoPlayerComponent
     /// - Usage: Showcase/Demo - Play local SBS file (endoscope-demo.mp4) in 3D
-    case fileDemo = "Demo"
+    case fileDemo = "3D Demo"
 
     /// Stage 1: Raw stream view (mono or SBS as-is)
     /// - Purpose: Verify incoming video feed before any processing
@@ -42,8 +48,8 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
         switch self {
         case .rawStream, .splitSBS, .stereo3D:
             return true
-        case .fileDemo:
-            return false  // File-based mode doesn't need WebRTC
+        case .fileDemo, .fileDemo2D:
+            return false  // File-based modes don't need WebRTC
         }
     }
 
@@ -53,7 +59,8 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
         case .rawStream: return "video.fill"
         case .splitSBS: return "rectangle.split.2x1.fill"
         case .stereo3D: return "view.3d"
-        case .fileDemo: return "play.circle.fill"
+        case .fileDemo: return "cube.fill"
+        case .fileDemo2D: return "play.rectangle.fill"
         }
     }
 
@@ -64,6 +71,7 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
         case .splitSBS: return "SBS 좌/우 분할 (디버그)"
         case .stereo3D: return "입체 3D (프로덕션)"
         case .fileDemo: return "3D 데모 (파일)"
+        case .fileDemo2D: return "2D 데모 (파일)"
         }
     }
 
@@ -71,7 +79,7 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
     var usesMetal: Bool {
         switch self {
         case .rawStream, .splitSBS: return true
-        case .stereo3D, .fileDemo: return false
+        case .stereo3D, .fileDemo, .fileDemo2D: return false
         }
     }
 
@@ -79,7 +87,7 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
     var usesVideoPlayer: Bool {
         switch self {
         case .stereo3D, .fileDemo: return true
-        case .rawStream, .splitSBS: return false
+        case .rawStream, .splitSBS, .fileDemo2D: return false  // fileDemo2D uses VideoMaterial instead
         }
     }
 
@@ -88,7 +96,7 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
         switch self {
         case .stereo3D: return true  // WebRTC path needs tagging
         case .fileDemo: return false  // SerialProcessor already tagged
-        case .rawStream, .splitSBS: return false
+        case .rawStream, .splitSBS, .fileDemo2D: return false
         }
     }
 
@@ -97,7 +105,7 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
         switch self {
         case .splitSBS, .stereo3D: return true
         case .fileDemo: return false  // SerialProcessor already split
-        case .rawStream: return false
+        case .rawStream, .fileDemo2D: return false  // fileDemo2D is mono, no split needed
         }
     }
 
@@ -105,11 +113,27 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
 
     /// Whether this is a WebRTC mode (not file demo)
     var isWebRTCMode: Bool {
-        self != .fileDemo
+        switch self {
+        case .rawStream, .splitSBS, .stereo3D: return true
+        case .fileDemo, .fileDemo2D: return false
+        }
     }
 
-    /// Whether this is Demo mode
+    /// Whether this is Demo mode (file-based)
     var isDemoMode: Bool {
+        switch self {
+        case .fileDemo, .fileDemo2D: return true
+        case .rawStream, .splitSBS, .stereo3D: return false
+        }
+    }
+
+    /// Whether this is 2D Demo mode
+    var is2DDemo: Bool {
+        self == .fileDemo2D
+    }
+
+    /// Whether this is 3D Demo mode
+    var is3DDemo: Bool {
         self == .fileDemo
     }
 
@@ -120,7 +144,70 @@ public enum EndoscopeViewMode: String, CaseIterable, Identifiable {
         case .rawStream: return .splitSBS
         case .splitSBS:  return .stereo3D
         case .stereo3D:  return .rawStream
-        case .fileDemo:  return .rawStream  // Fallback (should not be called)
+        case .fileDemo, .fileDemo2D:  return .rawStream  // Fallback (should not be called)
+        }
+    }
+}
+
+// MARK: - Render Configuration
+
+/// Video layout type for rendering
+public enum VideoLayout {
+    /// 2D plane - same texture for both eyes
+    case monoPlane
+    /// File-based SBS → split to left/right stereo
+    case stereoFromSBS
+    /// WebRTC stereo stream (already split)
+    case stereoStream
+}
+
+/// Video source type
+public enum VideoSource {
+    /// Local file playback
+    case file(url: URL)
+    /// WebRTC stream
+    case webrtc
+}
+
+/// Render configuration for each mode
+public struct EndoscopeRenderConfig {
+    public let layout: VideoLayout
+    public let source: VideoSource
+}
+
+extension EndoscopeViewMode {
+    /// Get render configuration for this mode
+    var renderConfig: EndoscopeRenderConfig {
+        switch self {
+        case .fileDemo2D:
+            return EndoscopeRenderConfig(
+                layout: .monoPlane,
+                source: .file(url: Bundle.main.url(forResource: "demo-2d", withExtension: "mp4")!)
+            )
+
+        case .fileDemo:
+            return EndoscopeRenderConfig(
+                layout: .stereoFromSBS,
+                source: .file(url: Bundle.main.url(forResource: "endoscope-demo", withExtension: "mp4")!)
+            )
+
+        case .rawStream:
+            return EndoscopeRenderConfig(
+                layout: .monoPlane,
+                source: .webrtc
+            )
+
+        case .splitSBS:
+            return EndoscopeRenderConfig(
+                layout: .monoPlane,
+                source: .webrtc
+            )
+
+        case .stereo3D:
+            return EndoscopeRenderConfig(
+                layout: .stereoStream,
+                source: .webrtc
+            )
         }
     }
 }

--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/ModeViews/FileDemo2DView.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/ModeViews/FileDemo2DView.swift
@@ -1,0 +1,140 @@
+//
+//  FileDemo2DView.swift
+//  Hippo
+//
+//  2D file demo view using AVPlayer + VideoMaterial
+//  Plays demo-2d.mp4 as a flat 2D plane (no SBS split, no stereo)
+//
+
+import SwiftUI
+import RealityKit
+import AVFoundation
+import AVKit
+import os.log
+
+/// 2D file demo view - plays demo-2d.mp4 using AVPlayer and VideoMaterial
+/// This is the default demo mode, showing video on a flat plane
+struct FileDemo2DView: View {
+    private let logger = Logger(
+        subsystem: "com.television.hippo",
+        category: "FileDemo2DView"
+    )
+
+    // AVPlayer for video playback
+    @State private var player: AVPlayer?
+
+    // Looping observer
+    @State private var loopObserver: NSObjectProtocol?
+
+    // Entity name for tracking
+    private static let entityName = "2d-video-entity"
+
+    var body: some View {
+        #if os(visionOS)
+        RealityView { content in
+            logger.info("FileDemo2DView: Creating RealityView for 2D demo")
+
+            // Get video URL from bundle
+            guard let videoURL = Bundle.main.url(forResource: "demo-2d", withExtension: "mp4") else {
+                logger.error("❌ demo-2d.mp4 not found in bundle")
+                return
+            }
+
+            logger.info("   Video URL: \(videoURL.lastPathComponent)")
+
+            // Create AVPlayer
+            let avPlayer = AVPlayer(url: videoURL)
+            avPlayer.actionAtItemEnd = .none  // Don't stop at end (we'll loop manually)
+
+            // Create VideoMaterial with AVPlayer
+            let material = VideoMaterial(avPlayer: avPlayer)
+
+            // Create plane entity with 16:9 aspect ratio
+            // Size tuned for comfortable viewing in Vision Pro
+            let planeWidth: Float = 1.6
+            let planeHeight: Float = 0.9  // 16:9 aspect ratio
+            let planeMesh = MeshResource.generatePlane(width: planeWidth, height: planeHeight)
+
+            let planeEntity = ModelEntity(mesh: planeMesh, materials: [material])
+            planeEntity.name = Self.entityName
+            planeEntity.position = SIMD3<Float>(0, 0, 0)  // Centered at origin
+
+            content.add(planeEntity)
+
+            // Start playback
+            avPlayer.play()
+
+            logger.info("✅ FileDemo2DView: 2D video playback started")
+            logger.info("   Plane size: \(planeWidth) × \(planeHeight)")
+            logger.info("   Position: \(planeEntity.position)")
+
+            // Store player reference for cleanup
+            Task { @MainActor in
+                self.player = avPlayer
+                setupLooping(player: avPlayer)
+            }
+
+        } update: { _ in
+            // No update needed for simple 2D playback
+        }
+        .frame(depth: 0)
+        .onAppear {
+            logger.info("FileDemo2DView appeared")
+        }
+        .onDisappear {
+            logger.info("FileDemo2DView disappeared - cleaning up")
+            cleanup()
+        }
+        #else
+        Color.black
+            .overlay(
+                Text("2D Video playback requires visionOS")
+                    .foregroundColor(.white)
+            )
+        #endif
+    }
+
+    // MARK: - Private Methods
+
+    /// Setup looping playback
+    private func setupLooping(player: AVPlayer) {
+        // Remove existing observer if any
+        if let observer = loopObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+
+        // Add observer for end of playback
+        loopObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: player.currentItem,
+            queue: .main
+        ) { [weak player] _ in
+            logger.debug("🔄 Video ended - looping back to start")
+            player?.seek(to: .zero)
+            player?.play()
+        }
+
+        logger.info("   Loop observer configured")
+    }
+
+    /// Cleanup resources
+    private func cleanup() {
+        // Remove loop observer
+        if let observer = loopObserver {
+            NotificationCenter.default.removeObserver(observer)
+            loopObserver = nil
+        }
+
+        // Stop and release player
+        player?.pause()
+        player = nil
+
+        logger.info("   Resources cleaned up")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    FileDemo2DView()
+}

--- a/Hippo/Features/Vision/UI/Immersive/Endoscope/StreamUIState.swift
+++ b/Hippo/Features/Vision/UI/Immersive/Endoscope/StreamUIState.swift
@@ -19,7 +19,8 @@ final class StreamUIState: ObservableObject {
     // MARK: - Published Properties
 
     /// Currently active (fully prepared and visible) mode
-    @Published var activeMode: EndoscopeViewMode = .fileDemo
+    /// Default: fileDemo2D (2D demo for initial showcase)
+    @Published var activeMode: EndoscopeViewMode = .fileDemo2D
 
     /// Whether a mode transition is in progress
     @Published var isSwitching: Bool = false
@@ -38,7 +39,7 @@ final class StreamUIState: ObservableObject {
 
     // MARK: - Initialization
 
-    init(initialMode: EndoscopeViewMode = .fileDemo) {
+    init(initialMode: EndoscopeViewMode = .fileDemo2D) {
         self.activeMode = initialMode
         logger.info("StreamUIState initialized with mode: \(initialMode.rawValue)")
     }
@@ -63,23 +64,23 @@ final class StreamUIState: ObservableObject {
         logger.info("🔄 Mode switch requested: \(self.activeMode.rawValue) → \(newMode.rawValue)")
 
         // Cleanup Demo mode resources if exiting from Demo
-        if activeMode == .fileDemo && newMode != .fileDemo {
+        if activeMode.isDemoMode && !newMode.isDemoMode {
             logger.info("   Exiting Demo mode - triggering cleanup...")
             onExitDemoMode?()
         }
 
-        // CRITICAL: Demo mode is now handled by PrimaryModeToggle
-        // Demo 진입: PrimaryModeToggle → stopAll() → configure(.fileDemo) → update UI
-        // This ensures FileDemoFrameSource is properly initialized
-        if newMode == .fileDemo {
-            logger.info("⚠️ switchMode() called for Demo mode")
+        // CRITICAL: Demo modes are now handled by PrimaryModeToggle
+        // Demo 진입: PrimaryModeToggle → stopAll() → configure(.fileDemo/.fileDemo2D) → update UI
+        // This ensures proper initialization for file-based modes
+        if newMode.isDemoMode {
+            logger.info("⚠️ switchMode() called for Demo mode: \(newMode.rawValue)")
             logger.info("   Note: Demo configuration should be handled by PrimaryModeToggle")
             logger.info("   Updating UI state only")
             isSwitching = true
-            activeMode = .fileDemo
+            activeMode = newMode
             try? await Task.sleep(for: .milliseconds(50))
             isSwitching = false
-            logger.info("✅ Mode switch complete (UI updated to Demo)")
+            logger.info("✅ Mode switch complete (UI updated to \(newMode.rawValue))")
             return
         }
 

--- a/Hippo/Features/Vision/UI/Operation/Recording/RecordingPlayerView.swift
+++ b/Hippo/Features/Vision/UI/Operation/Recording/RecordingPlayerView.swift
@@ -12,7 +12,6 @@ struct RecordingPlayerView: View {
     let spacing = 20.0
 
     @Environment(AppModel.self) private var appModel
-    @Environment(SceneProvider.self) private var sceneProvider
     @State private var viewModel = RecordingViewModel()
 
     init(recordings: [OperationRecording]) {
@@ -30,9 +29,5 @@ struct RecordingPlayerView: View {
         .padding(spacing)
         .scrollIndicators(.hidden)
         .environment(viewModel)
-        .onChange(of: sceneProvider.scene, initial: true) { _, newScene in
-            // Update the player model with the new scene.
-            viewModel.scene = newScene
-        }
     }
 }


### PR DESCRIPTION
## 📕 Issue Number

Close #195 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- fileDemo2D 모드 추가 (demo-2d.mp4, AVPlayer + VideoMaterial 기반)
- 기존 3D Demo (endoscope-demo.mp4) 모드는 fileDemo로 유지
- 앱 시작 시 기본 모드를 2D Demo로 변경
- PrimaryModeToggle에 [WebRTC] [2D Demo] [3D Demo] 3개 버튼 추가
- FileDemo2DView 신규 생성 (파이프라인 우회, 단순 2D 재생)
- EndoscopeViewMode에 renderConfig 프로퍼티 추가


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

- 스크린 샷


## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

