### PR TITLE
feat: Mac 앱 내장 시그널링 서버 및 WebRTC 연결 안정성 개선

### DIFF
--- a/Hippo.xcodeproj/project.pbxproj
+++ b/Hippo.xcodeproj/project.pbxproj
@@ -300,6 +300,9 @@
 		25BF39172ED62C8100B797AA /* EndoscopeTopControlBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF39162ED62C8100B797AA /* EndoscopeTopControlBar.swift */; };
 		25BF39192ED633D600B797AA /* DemoDisplayModeToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF39182ED633D600B797AA /* DemoDisplayModeToggle.swift */; };
 		25BF391B2ED6386100B797AA /* FileDemoImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF391A2ED6386100B797AA /* FileDemoImageView.swift */; };
+		25BF39202ED77CF600B797AA /* SignalingServerTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF391E2ED77CF600B797AA /* SignalingServerTypes.swift */; };
+		25BF39212ED77CF600B797AA /* EmbeddedSignalingServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF391C2ED77CF600B797AA /* EmbeddedSignalingServer.swift */; };
+		25BF39222ED77CF600B797AA /* SignalingConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25BF391D2ED77CF600B797AA /* SignalingConnection.swift */; };
 		25DEMO2D012ED60000001442 /* FileDemo2DView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DEMO2D002ED60000001442 /* FileDemo2DView.swift */; };
 		25E78B602EB90D4600D8CAD2 /* OperationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E78B5D2EB90D4600D8CAD2 /* OperationStatus.swift */; };
 		25E78B612EB90D4600D8CAD2 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E78B542EB90D4600D8CAD2 /* Operation.swift */; };
@@ -706,6 +709,9 @@
 		25BF39162ED62C8100B797AA /* EndoscopeTopControlBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndoscopeTopControlBar.swift; sourceTree = "<group>"; };
 		25BF39182ED633D600B797AA /* DemoDisplayModeToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoDisplayModeToggle.swift; sourceTree = "<group>"; };
 		25BF391A2ED6386100B797AA /* FileDemoImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDemoImageView.swift; sourceTree = "<group>"; };
+		25BF391C2ED77CF600B797AA /* EmbeddedSignalingServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedSignalingServer.swift; sourceTree = "<group>"; };
+		25BF391D2ED77CF600B797AA /* SignalingConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalingConnection.swift; sourceTree = "<group>"; };
+		25BF391E2ED77CF600B797AA /* SignalingServerTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalingServerTypes.swift; sourceTree = "<group>"; };
 		25DEMO2D002ED60000001442 /* FileDemo2DView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDemo2DView.swift; sourceTree = "<group>"; };
 		25E78B542EB90D4600D8CAD2 /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
 		25E78B552EB90D4600D8CAD2 /* OperationAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationAsset.swift; sourceTree = "<group>"; };
@@ -1281,6 +1287,7 @@
 		2523A6592EC4C3A900842508 /* Endoscope */ = {
 			isa = PBXGroup;
 			children = (
+				25BF391F2ED77CF600B797AA /* Signaling */,
 				2523A6452EC4C3A900842508 /* AppModule */,
 				2523A64B2EC4C3A900842508 /* Capture */,
 				2523A6502EC4C3A900842508 /* Composer */,
@@ -1549,6 +1556,16 @@
 				253881CA2ECA3C00001442C9 /* Stereo3DView.swift */,
 			);
 			path = ModeViews;
+			sourceTree = "<group>";
+		};
+		25BF391F2ED77CF600B797AA /* Signaling */ = {
+			isa = PBXGroup;
+			children = (
+				25BF391C2ED77CF600B797AA /* EmbeddedSignalingServer.swift */,
+				25BF391D2ED77CF600B797AA /* SignalingConnection.swift */,
+				25BF391E2ED77CF600B797AA /* SignalingServerTypes.swift */,
+			);
+			path = Signaling;
 			sourceTree = "<group>";
 		};
 		25E78B522EB90D4600D8CAD2 /* Commands */ = {
@@ -2630,6 +2647,9 @@
 				2581FF4D2EBE576E0059678D /* ModeButton.swift in Sources */,
 				1494DE9A2EA73359000CD284 /* SectionTitle.swift in Sources */,
 				C04678332EA00B3A00D160DA /* PatientRemoteDataSource.swift in Sources */,
+				25BF39202ED77CF600B797AA /* SignalingServerTypes.swift in Sources */,
+				25BF39212ED77CF600B797AA /* EmbeddedSignalingServer.swift in Sources */,
+				25BF39222ED77CF600B797AA /* SignalingConnection.swift in Sources */,
 				C04678472EA00C2700D160DA /* PatientView.swift in Sources */,
 				C046781C2EA00B1F00D160DA /* DeletePatient.swift in Sources */,
 				06EF5FE62EC70F1A00E1BACC /* AssetThumbnailView.swift in Sources */,

--- a/Hippo/Features/Mac/Endoscope/AppModule/AppModule.swift
+++ b/Hippo/Features/Mac/Endoscope/AppModule/AppModule.swift
@@ -50,6 +50,7 @@ public final class AppModule: ObservableObject {
     private var frameSync: FrameSync?
     private var composer: CI_SBSComposer?
     private var transport: WebRTCManager?
+    private var signalingClient: SignalingClient?
 
     // P0.2: Actor-based configuration
     private let configManager = PipelineConfigurationManager()
@@ -99,8 +100,15 @@ public final class AppModule: ObservableObject {
         leftCapture?.delegate = self
         rightCapture?.delegate = self
 
-        // 5. Start transport
-        try transport?.start()
+        // 5. Setup signaling and start transport
+        let serverURL = URL(string: "ws://127.0.0.1:8080")!
+        signalingClient = SignalingClient(serverURL: serverURL)
+        try signalingClient?.connect(as: "sender")
+
+        guard let signalingClient = signalingClient else {
+            throw VideoError.invalidConfiguration(reason: "Failed to create signaling client")
+        }
+        try transport?.start(with: signalingClient)
 
         // 6. Start capture sessions
         try leftCapture?.start()
@@ -120,12 +128,14 @@ public final class AppModule: ObservableObject {
         frameSync?.reset()
 
         transport?.stop()
+        signalingClient?.disconnect()
 
         leftCapture = nil
         rightCapture = nil
         frameSync = nil
         composer = nil
         transport = nil
+        signalingClient = nil
 
         isStreaming = false
         logger.info("Streaming pipeline stopped")

--- a/Hippo/Features/Mac/Endoscope/Signaling/EmbeddedSignalingServer.swift
+++ b/Hippo/Features/Mac/Endoscope/Signaling/EmbeddedSignalingServer.swift
@@ -1,0 +1,366 @@
+//
+//  EmbeddedSignalingServer.swift
+//  Hippo
+//
+//  Embedded WebSocket Signaling Server for Mac app
+//  - Replaces the need for external `node server.js`
+//  - Role-based client management (sender/receiver)
+//  - Bonjour (mDNS) auto-discovery publishing
+//
+
+import Foundation
+import Network
+import os.log
+import Combine
+
+// MARK: - Embedded Signaling Server
+
+@MainActor
+public final class EmbeddedSignalingServer: ObservableObject {
+
+    // MARK: - Published Properties
+
+    @Published public private(set) var state: SignalingServerState = .idle
+    @Published public private(set) var connectedClients: Int = 0
+    @Published public private(set) var hasSender: Bool = false
+    @Published public private(set) var hasReceiver: Bool = false
+
+    // MARK: - Private Properties
+
+    private let logger = Logger(subsystem: "com.television.hippo", category: "SignalingServer")
+    private let configuration: SignalingServerConfiguration
+
+    // Network components
+    private var listener: NWListener?
+    private let listenerQueue = DispatchQueue(label: "com.television.hippo.signaling", qos: .userInteractive)
+
+    // Client management
+    private var clients: [UUID: SignalingConnection] = [:]
+    private var senderClient: SignalingConnection?
+    private var receiverClient: SignalingConnection?
+
+    // Heartbeat
+    private var heartbeatTimer: Timer?
+
+    // MARK: - Initialization
+
+    public init(configuration: SignalingServerConfiguration = .default) {
+        self.configuration = configuration
+    }
+
+    // MARK: - Public API
+
+    public func start() {
+        // Don't start if already running or starting
+        switch state {
+        case .running, .starting:
+            logger.info("Server already running or starting, skipping...")
+            return
+        case .idle, .stopped, .failed:
+            break  // OK to start
+        }
+
+        state = .starting
+        logger.info("🚀 Starting signaling server on port \(self.configuration.port)...")
+
+        do {
+            let parameters = NWParameters.tcp
+            parameters.allowLocalEndpointReuse = true
+
+            // Enable WebSocket
+            let wsOptions = NWProtocolWebSocket.Options()
+            wsOptions.autoReplyPing = true
+            parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
+
+            listener = try NWListener(using: parameters, on: NWEndpoint.Port(rawValue: configuration.port)!)
+
+            listener?.stateUpdateHandler = { [weak self] newState in
+                Task { @MainActor [weak self] in
+                    self?.handleListenerState(newState)
+                }
+            }
+
+            listener?.newConnectionHandler = { [weak self] connection in
+                Task { @MainActor [weak self] in
+                    self?.handleNewConnection(connection)
+                }
+            }
+
+            // Bonjour advertising
+            listener?.service = NWListener.Service(
+                name: configuration.serviceName,
+                type: "_ws._tcp",
+                txtRecord: NWTXTRecord(["service": "webrtc-signaling", "version": "1.0"])
+            )
+
+            listener?.start(queue: listenerQueue)
+            startHeartbeat()
+
+        } catch {
+            logger.error("❌ Failed to start: \(error.localizedDescription)")
+            state = .failed(error: error.localizedDescription)
+        }
+    }
+
+    public func stop() {
+        logger.info("🛑 Stopping signaling server...")
+
+        heartbeatTimer?.invalidate()
+        heartbeatTimer = nil
+
+        for client in clients.values {
+            client.connection.cancel()
+        }
+        clients.removeAll()
+        senderClient = nil
+        receiverClient = nil
+
+        listener?.cancel()
+        listener = nil
+
+        state = .stopped
+        connectedClients = 0
+        hasSender = false
+        hasReceiver = false
+    }
+
+    // MARK: - Listener State
+
+    private func handleListenerState(_ newState: NWListener.State) {
+        switch newState {
+        case .ready:
+            logger.info("✅ Server ready on port \(self.configuration.port)")
+            state = .running(port: configuration.port)
+            printServerInfo()
+
+        case .failed(let error):
+            logger.error("❌ Server failed: \(error.localizedDescription)")
+            state = .failed(error: error.localizedDescription)
+
+        case .cancelled:
+            if case .running = state { state = .stopped }
+
+        default:
+            break
+        }
+    }
+
+    private func printServerInfo() {
+        print("")
+        print("╔═══════════════════════════════════════════════╗")
+        print("║   Embedded WebRTC Signaling Server Started    ║")
+        print("╚═══════════════════════════════════════════════╝")
+        print("   Port: \(configuration.port) | Bonjour: _ws._tcp")
+        print("")
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleNewConnection(_ connection: NWConnection) {
+        let client = SignalingConnection(connection: connection)
+        clients[client.id] = client
+
+        logger.info("🔌 New connection: \(client.id)")
+
+        connection.stateUpdateHandler = { [weak self, weak client] state in
+            guard let client = client else { return }
+            Task { @MainActor [weak self] in
+                if case .cancelled = state { self?.removeClient(client) }
+                if case .failed = state { self?.removeClient(client) }
+            }
+        }
+
+        connection.start(queue: listenerQueue)
+        receiveMessage(from: client)
+        updateClientCount()
+    }
+
+    private func removeClient(_ client: SignalingConnection) {
+        logger.info("👋 Disconnected: \(client.displayName)")
+
+        if client.role == "sender" {
+            senderClient = nil
+            hasSender = false
+        } else if client.role == "receiver" {
+            receiverClient = nil
+            hasReceiver = false
+        }
+
+        clients.removeValue(forKey: client.id)
+        updateClientCount()
+    }
+
+    private func updateClientCount() {
+        connectedClients = clients.count
+    }
+
+    // MARK: - Message Handling
+
+    private func receiveMessage(from client: SignalingConnection) {
+        client.connection.receiveMessage { [weak self, weak client] content, context, _, error in
+            guard let self = self, let client = client else { return }
+
+            if error != nil { return }
+
+            if let context = context,
+               let metadata = context.protocolMetadata(definition: NWProtocolWebSocket.definition) as? NWProtocolWebSocket.Metadata {
+
+                switch metadata.opcode {
+                case .text:
+                    if let data = content, let text = String(data: data, encoding: .utf8) {
+                        Task { @MainActor in self.handleMessage(text, from: client) }
+                    }
+                case .pong:
+                    Task { @MainActor in client.isAlive = true }
+                case .close:
+                    Task { @MainActor in self.removeClient(client) }
+                    return
+                default:
+                    break
+                }
+            }
+
+            self.receiveMessage(from: client)
+        }
+    }
+
+    private func handleMessage(_ text: String, from client: SignalingConnection) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String else { return }
+
+        switch type {
+        case "register":
+            handleRegister(json, from: client)
+        case "offer":
+            handleOffer(json)
+        case "answer":
+            handleAnswer(json)
+        case "iceCandidate", "ice-candidate":
+            handleIceCandidate(json, from: client)
+        default:
+            break
+        }
+    }
+
+    // MARK: - Message Handlers
+
+    private func handleRegister(_ json: [String: Any], from client: SignalingConnection) {
+        guard let role = json["role"] as? String ?? json["clientId"] as? String else { return }
+
+        client.role = role
+
+        if role == "sender" {
+            if let existing = senderClient {
+                existing.connection.cancel()
+                removeClient(existing)
+            }
+            senderClient = client
+            hasSender = true
+            logger.info("📱 SENDER registered")
+
+            sendJSON(["type": "registered", "role": "sender"], to: client)
+
+            if receiverClient != nil {
+                sendJSON(["type": "ready", "message": "Receiver connected"], to: client)
+            }
+
+        } else if role == "receiver" {
+            if let existing = receiverClient {
+                existing.connection.cancel()
+                removeClient(existing)
+            }
+            receiverClient = client
+            hasReceiver = true
+            logger.info("🥽 RECEIVER registered")
+
+            sendJSON(["type": "registered", "role": "receiver"], to: client)
+
+            if let sender = senderClient {
+                sendJSON(["type": "ready", "message": "Receiver connected"], to: sender)
+            }
+        }
+    }
+
+    private func handleOffer(_ json: [String: Any]) {
+        guard let sdp = json["sdp"] as? String,
+              let receiver = receiverClient else { return }
+
+        logger.info("📄 OFFER → receiver")
+        sendJSON(["type": "offer", "sdp": sdp], to: receiver)
+    }
+
+    private func handleAnswer(_ json: [String: Any]) {
+        guard let sdp = json["sdp"] as? String,
+              let sender = senderClient else { return }
+
+        logger.info("📄 ANSWER → sender")
+        sendJSON(["type": "answer", "sdp": sdp], to: sender)
+    }
+
+    private func handleIceCandidate(_ json: [String: Any], from client: SignalingConnection) {
+        guard let candidate = json["candidate"] as? String else { return }
+
+        let sdpMid = json["sdpMid"] as? String
+        let sdpMLineIndex = json["sdpMLineIndex"] as? Int32 ?? 0
+
+        let target = (client === senderClient) ? receiverClient : senderClient
+        guard let target = target else { return }
+
+        client.iceCandidatesSent += 1
+
+        if client.iceCandidatesSent % 5 == 0 {
+            logger.info("🧊 ICE: \(client.iceCandidatesSent) candidates forwarded")
+        }
+
+        sendJSON([
+            "type": "iceCandidate",
+            "candidate": candidate,
+            "sdpMid": sdpMid as Any,
+            "sdpMLineIndex": sdpMLineIndex
+        ], to: target)
+    }
+
+    // MARK: - Send Helper
+
+    private func sendJSON(_ json: [String: Any], to client: SignalingConnection) {
+        guard let data = try? JSONSerialization.data(withJSONObject: json),
+              let text = String(data: data, encoding: .utf8) else { return }
+
+        let metadata = NWProtocolWebSocket.Metadata(opcode: .text)
+        let context = NWConnection.ContentContext(identifier: "text", metadata: [metadata])
+
+        client.connection.send(
+            content: text.data(using: .utf8),
+            contentContext: context,
+            isComplete: true,
+            completion: .contentProcessed { _ in }
+        )
+    }
+
+    // MARK: - Heartbeat
+
+    private func startHeartbeat() {
+        heartbeatTimer = Timer.scheduledTimer(withTimeInterval: configuration.heartbeatInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.performHeartbeat()
+            }
+        }
+    }
+
+    private func performHeartbeat() {
+        for client in clients.values {
+            if !client.isAlive {
+                client.connection.cancel()
+                removeClient(client)
+                continue
+            }
+
+            client.isAlive = false
+
+            let metadata = NWProtocolWebSocket.Metadata(opcode: .ping)
+            let context = NWConnection.ContentContext(identifier: "ping", metadata: [metadata])
+            client.connection.send(content: nil, contentContext: context, isComplete: true, completion: .contentProcessed { _ in })
+        }
+    }
+}

--- a/Hippo/Features/Mac/Endoscope/Signaling/SignalingConnection.swift
+++ b/Hippo/Features/Mac/Endoscope/Signaling/SignalingConnection.swift
@@ -1,0 +1,43 @@
+//
+//  SignalingConnection.swift
+//  Hippo
+//
+//  Represents a connected WebSocket client to the signaling server
+//
+
+import Foundation
+import Network
+
+// MARK: - Signaling Connection
+
+/// Represents a connected WebSocket client
+final class SignalingConnection: @unchecked Sendable {
+
+    // MARK: - Properties
+
+    let id: UUID
+    let connection: NWConnection
+    var role: String?
+    var isAlive: Bool = true
+
+    // ICE candidate statistics
+    var iceCandidatesSent: Int = 0
+    var iceCandidatesReceived: Int = 0
+
+    // MARK: - Initialization
+
+    init(connection: NWConnection) {
+        self.id = UUID()
+        self.connection = connection
+    }
+
+    // MARK: - Helpers
+
+    var displayName: String {
+        switch role {
+        case "sender": return "Mac (Sender)"
+        case "receiver": return "Vision Pro (Receiver)"
+        default: return "Unknown"
+        }
+    }
+}

--- a/Hippo/Features/Mac/Endoscope/Signaling/SignalingServerTypes.swift
+++ b/Hippo/Features/Mac/Endoscope/Signaling/SignalingServerTypes.swift
@@ -1,0 +1,38 @@
+//
+//  SignalingServerTypes.swift
+//  Hippo
+//
+//  Types and configuration for embedded signaling server
+//
+
+import Foundation
+
+// MARK: - Signaling Server State
+
+public enum SignalingServerState: Equatable {
+    case idle
+    case starting
+    case running(port: UInt16)
+    case failed(error: String)
+    case stopped
+}
+
+// MARK: - Server Configuration
+
+public struct SignalingServerConfiguration {
+    public var port: UInt16
+    public var serviceName: String
+    public var heartbeatInterval: TimeInterval
+
+    public static let `default` = SignalingServerConfiguration(
+        port: 8080,
+        serviceName: "Hippo-WebRTC-Signaling",
+        heartbeatInterval: 30.0
+    )
+
+    public init(port: UInt16, serviceName: String, heartbeatInterval: TimeInterval) {
+        self.port = port
+        self.serviceName = serviceName
+        self.heartbeatInterval = heartbeatInterval
+    }
+}

--- a/Hippo/Features/Mac/Endoscope/Transport/WebRTCManager.swift
+++ b/Hippo/Features/Mac/Endoscope/Transport/WebRTCManager.swift
@@ -53,8 +53,14 @@ public final class WebRTCManager: NSObject, IVideoTransport {
     private var videoSender: LKRTCRtpSender?
     private var videoCapturer: LKRTCVideoCapturer?
 
-    private var signalingClient: SignalingClient?
+    // External signaling client (injected from ViewModel)
+    private weak var signalingClient: SignalingClient?
     private let config: TransportConfig
+
+    /// Callback when offer is created (for external signaling)
+    public var onOfferCreated: ((String) -> Void)?
+    /// Callback when ICE candidate is generated
+    public var onIceCandidateGenerated: ((LKRTCIceCandidate) -> Void)?
 
     // MARK: Queues
 
@@ -97,9 +103,13 @@ public final class WebRTCManager: NSObject, IVideoTransport {
 
     // MARK: - ITransport
 
-    public func start() throws {
-        logger.info("WebRTC starting...")
-        print("[WebRTCManager] Starting WebRTC transport...")
+    /// Start WebRTC with external signaling client
+    /// - Parameter signalingClient: External SignalingClient managed by ViewModel
+    public func start(with signalingClient: SignalingClient) throws {
+        self.signalingClient = signalingClient
+
+        logger.info("WebRTC starting with external signaling...")
+        print("[WebRTCManager] Starting WebRTC transport with external signaling...")
         state = .connecting
 
         // 1. Initialize WebRTC factory
@@ -117,29 +127,22 @@ public final class WebRTCManager: NSObject, IVideoTransport {
         )
         print("[WebRTCManager] Peer connection factory created with HEVC support")
 
-        // 2. Setup signaling FIRST (before creating peer connection)
-        let serverURL = URL(string: "ws://127.0.0.1:8080")!
-        print("[WebRTCManager] Creating SignalingClient for: \(serverURL.absoluteString)")
-        signalingClient = SignalingClient(serverURL: serverURL)
-        signalingClient?.delegate = self
-
-        print("[WebRTCManager] Connecting to signaling server as 'sender'...")
-        try signalingClient?.connect(as: "sender")
-
-        // 3. Create peer connection (but DON'T create offer yet)
+        // 2. Create peer connection
         print("[WebRTCManager] Creating peer connection...")
         try createPeerConnection()
 
-        // 4. Create video track
+        // 3. Create video track
         print("[WebRTCManager] Creating video track...")
         createVideoTrack()
 
-        // 5. Offer will be created in signalingClient(_:didChangeState:) when connected
-        print("[WebRTCManager] Waiting for signaling connection before creating offer...")
+        // 4. Create offer immediately (signaling is already connected)
+        print("[WebRTCManager] Creating offer...")
+        createOffer()
 
-        logger.info("WebRTC initialized (waiting for signaling)")
-        print("[WebRTCManager] WebRTC initialization complete (waiting for signaling)")
+        logger.info("WebRTC initialized and offer created")
+        print("[WebRTCManager] WebRTC initialization complete")
     }
+
 
     public func stop() {
         logger.info("WebRTC stopping...")
@@ -157,8 +160,7 @@ public final class WebRTCManager: NSObject, IVideoTransport {
         videoSource = nil
         videoSender = nil
 
-        // 3. Disconnect signaling (fast, non-blocking after our fix)
-        signalingClient?.disconnect()
+        // 3. Clear signaling reference (don't disconnect - managed by ViewModel)
         signalingClient = nil
 
         // 4. Close peer connection in background (may block)
@@ -395,6 +397,51 @@ public final class WebRTCManager: NSObject, IVideoTransport {
         disconnectionTimer?.invalidate()
         disconnectionTimer = nil
     }
+
+    // MARK: - Public: Signaling Message Handlers
+
+    /// Handle SDP answer from remote peer (called by ViewModel)
+    public func handleAnswer(sdp: String) {
+        print("📄 SDP Answer received")
+        let sessionDescription = LKRTCSessionDescription(type: .answer, sdp: sdp)
+
+        peerConnection?.setRemoteDescription(sessionDescription) { [weak self] error in
+            guard let self = self else { return }
+
+            if let error = error {
+                self.logger.error("Failed to set remote description: \(error.localizedDescription)")
+                return
+            }
+
+            self.logger.info("Remote description set (answer)")
+            self.remoteDescriptionSet = true
+
+            // Process pending ICE candidates
+            for candidate in self.pendingRemoteCandidates {
+                self.peerConnection?.add(candidate) { error in
+                    if let error = error {
+                        self.logger.error("Failed to add ICE candidate: \(error.localizedDescription)")
+                    }
+                }
+            }
+            self.pendingRemoteCandidates.removeAll()
+        }
+    }
+
+    /// Handle remote ICE candidate (called by ViewModel)
+    public func handleRemoteCandidate(candidate: String, sdpMid: String?, sdpMLineIndex: Int32) {
+        let iceCandidate = LKRTCIceCandidate(sdp: candidate, sdpMLineIndex: sdpMLineIndex, sdpMid: sdpMid)
+
+        if remoteDescriptionSet {
+            peerConnection?.add(iceCandidate) { [weak self] error in
+                if let error = error {
+                    self?.logger.error("Failed to add ICE candidate: \(error.localizedDescription)")
+                }
+            }
+        } else {
+            pendingRemoteCandidates.append(iceCandidate)
+        }
+    }
 }
 
 // MARK: - LKRTCPeerConnectionDelegate
@@ -457,68 +504,3 @@ extension WebRTCManager: LKRTCPeerConnectionDelegate {
     public func peerConnection(_ peerConnection: LKRTCPeerConnection, didStartReceivingOn transceiver: LKRTCRtpTransceiver) {}
 }
 
-// MARK: - SignalingDelegate
-
-extension WebRTCManager: SignalingDelegate {
-
-    func signalingClient(_ client: SignalingClient, didReceiveOffer sdp: String) {
-        // Sender doesn't handle offers
-    }
-
-    func signalingClient(_ client: SignalingClient, didReceiveAnswer sdp: String) {
-        print("📄 SDP Answer received")
-        let sessionDescription = LKRTCSessionDescription(type: .answer, sdp: sdp)
-
-        peerConnection?.setRemoteDescription(sessionDescription) { [weak self] error in
-            guard let self = self else { return }
-
-            if let error = error {
-                self.logger.error("Failed to set remote description: \(error.localizedDescription)")
-                return
-            }
-
-            self.logger.info("Remote description set (answer)")
-            self.remoteDescriptionSet = true
-
-            // Process pending ICE candidates
-            for candidate in self.pendingRemoteCandidates {
-                self.peerConnection?.add(candidate) { error in
-                    if let error = error {
-                        self.logger.error("Failed to add ICE candidate: \(error.localizedDescription)")
-                    }
-                }
-            }
-            self.pendingRemoteCandidates.removeAll()
-        }
-    }
-
-    func signalingClient(_ client: SignalingClient, didReceiveCandidate candidate: String, sdpMid: String?, sdpMLineIndex: Int32) {
-        let iceCandidate = LKRTCIceCandidate(sdp: candidate, sdpMLineIndex: sdpMLineIndex, sdpMid: sdpMid)
-
-        if remoteDescriptionSet {
-            peerConnection?.add(iceCandidate) { [weak self] error in
-                if let error = error {
-                    self?.logger.error("Failed to add ICE candidate: \(error.localizedDescription)")
-                }
-            }
-        } else {
-            pendingRemoteCandidates.append(iceCandidate)
-        }
-    }
-
-    func signalingClient(_ client: SignalingClient, didChangeState state: SignalingState) {
-        switch state {
-        case .connected:
-            logger.info("Signaling connected")
-            print("[WebRTCManager] Signaling connected, now creating offer...")
-
-            // Now that signaling is connected, create the offer
-            createOffer()
-
-        case .failed:
-            self.state = .failed
-        default:
-            break
-        }
-    }
-}

--- a/Hippo/Features/Mac/Endoscope/Transport/WebRTCManager.swift
+++ b/Hippo/Features/Mac/Endoscope/Transport/WebRTCManager.swift
@@ -103,6 +103,9 @@ public final class WebRTCManager: NSObject, IVideoTransport {
 
     // MARK: - ITransport
 
+    // Static flag to ensure WebRTC is initialized only once
+    private static var isWebRTCInitialized = false
+
     /// Start WebRTC with external signaling client
     /// - Parameter signalingClient: External SignalingClient managed by ViewModel
     public func start(with signalingClient: SignalingClient) throws {
@@ -112,10 +115,15 @@ public final class WebRTCManager: NSObject, IVideoTransport {
         print("[WebRTCManager] Starting WebRTC transport with external signaling...")
         state = .connecting
 
-        // 1. Initialize WebRTC factory
-        print("[WebRTCManager] Initializing WebRTC SSL and tracer...")
-        LKRTCInitializeSSL()
-        LKRTCSetupInternalTracer()
+        // 1. Initialize WebRTC factory (only once per app lifecycle)
+        if !Self.isWebRTCInitialized {
+            print("[WebRTCManager] Initializing WebRTC SSL and tracer (first time)...")
+            LKRTCInitializeSSL()
+            LKRTCSetupInternalTracer()
+            Self.isWebRTCInitialized = true
+        } else {
+            print("[WebRTCManager] WebRTC already initialized, skipping SSL/tracer setup")
+        }
 
         // Use HEVC encoder factory for better compression
         let encoderFactory = HEVCVideoEncoderFactory()
@@ -176,9 +184,8 @@ public final class WebRTCManager: NSObject, IVideoTransport {
         remoteDescriptionSet = false
         frameCount = 0
 
-        // 6. Cleanup WebRTC global state
-        LKRTCShutdownInternalTracer()
-        LKRTCCleanupSSL()
+        // 6. Don't cleanup WebRTC global state - it's shared and can only be initialized once
+        // LKRTCShutdownInternalTracer() and LKRTCCleanupSSL() cause crash if called before re-init
 
         state = .closed
         logger.info("✅ WebRTC stopped")
@@ -287,7 +294,8 @@ public final class WebRTCManager: NSObject, IVideoTransport {
         }
     }
 
-    private func createOffer() {
+    /// Create and send a new WebRTC offer (public for renegotiation)
+    public func createOffer() {
         print("[WebRTCManager] Creating offer (signaling state: \(signalingClient?.state.self ?? .disconnected))")
 
         let constraints = LKRTCMediaConstraints(

--- a/Hippo/Features/Mac/UI/Root/RootView.swift
+++ b/Hippo/Features/Mac/UI/Root/RootView.swift
@@ -19,15 +19,16 @@ struct RootView: View {
         NavigationStack {
             ZStack {
                 Color(.hippoBackground).ignoresSafeArea()
-                // 메인 컨텐츠는 선택된 탭에 따라 전환
-                Group {
-                    switch selectedTab {
-                    case .Home:
-                        HomeView()
-                    case .StreamingControl:
-                        StreamingControlView()
-                    }
-                }
+
+                // Keep both views alive, show/hide with opacity
+                // This prevents StreamingControlView from being recreated on tab switch
+                HomeView()
+                    .opacity(selectedTab == .Home ? 1 : 0)
+                    .allowsHitTesting(selectedTab == .Home)
+
+                StreamingControlView()
+                    .opacity(selectedTab == .StreamingControl ? 1 : 0)
+                    .allowsHitTesting(selectedTab == .StreamingControl)
 
                 VStack {
                     HStack {

--- a/Hippo/Features/Mac/UI/StreamingControl/Components/DevicePreview.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/Components/DevicePreview.swift
@@ -13,17 +13,21 @@ struct DevicePreview: NSViewRepresentable {
 
     func makeNSView(context: Context) -> PreviewLayerView {
         let view = PreviewLayerView()
-        view.displayLayer = preview
 
         // Configure the display layer
         preview.videoGravity = .resizeAspect
         preview.backgroundColor = NSColor.black.cgColor
 
+        view.displayLayer = preview
         return view
     }
 
     func updateNSView(_ nsView: PreviewLayerView, context: Context) {
-        // Update if needed
+        // Re-attach layer when view is updated (e.g., after tab switch)
+        // This is needed because the layer may have been removed from its superlayer
+        if preview.superlayer == nil {
+            nsView.displayLayer = preview
+        }
     }
 }
 
@@ -39,15 +43,22 @@ final class PreviewLayerView: NSView {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
+        // Disable implicit animations to prevent layout jumps
+        layer?.actions = ["sublayers": NSNull(), "bounds": NSNull(), "position": NSNull()]
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         wantsLayer = true
+        layer?.actions = ["sublayers": NSNull(), "bounds": NSNull(), "position": NSNull()]
     }
 
     private func setupLayer() {
         guard let layer = layer, let displayLayer = displayLayer else { return }
+
+        // Disable animations during setup
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
 
         // Remove old sublayer if exists
         layer.sublayers?.forEach { $0.removeFromSuperlayer() }
@@ -55,14 +66,17 @@ final class PreviewLayerView: NSView {
         // Add display layer as sublayer
         layer.addSublayer(displayLayer)
         displayLayer.frame = layer.bounds
+
+        CATransaction.commit()
     }
 
     override func layout() {
         super.layout()
 
         // Update display layer frame when view bounds change
-        if let layer = layer {
-            displayLayer?.frame = layer.bounds
-        }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        displayLayer?.frame = bounds
+        CATransaction.commit()
     }
 }

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlView.swift
@@ -22,9 +22,9 @@ enum CameraInputMode: String, CaseIterable {
 struct StreamingControlView: View {
     // MARK: - ViewModel
 
-    @State private var viewModel = StreamingControlViewModel()
-
-    private let videoLayer = AVSampleBufferDisplayLayer()
+    /// Use shared singleton to persist across tab switches
+    /// @Bindable allows $viewModel bindings to work with @Observable
+    @Bindable private var viewModel = StreamingControlViewModel.shared
 
     var body: some View {
         ScrollView {
@@ -62,7 +62,7 @@ struct StreamingControlView: View {
                     availableDevices: viewModel.availableDevices
                 )
 
-                PreviewSectionView(videoLayer: videoLayer)
+                PreviewSectionView(videoLayer: viewModel.previewLayer)
 
                 StreamingButton(
                     isStreaming: viewModel.isStreaming,
@@ -85,11 +85,6 @@ struct StreamingControlView: View {
             .padding(32)
             .inspector(isPresented: $viewModel.isInspectorPresented) {
                 StreamingInspectorView()
-            }
-            .task {
-                // View가 나타날 때 장치 목록 로드 및 preview layer 연결
-                viewModel.loadAvailableDevices()
-                viewModel.previewLayer = videoLayer
             }
         }
     }

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlViewModel.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlViewModel.swift
@@ -10,6 +10,7 @@ import AVFoundation
 import Observation
 import CoreVideo
 import CoreMedia
+import Combine
 import os.log
 
 // MARK: - Sendable Wrapper
@@ -40,6 +41,9 @@ public final class StreamingControlViewModel {
 
     // Signaling client for auto-start (always connected, waiting for receiver)
     private var signalingClient: SignalingClient?
+
+    // Bonjour service discovery for auto-detecting signaling server
+    private let bonjourDiscovery = BonjourServiceDiscovery()
 
     // Preview display layer (set from view)
     public var previewLayer: AVSampleBufferDisplayLayer?
@@ -161,6 +165,10 @@ public final class StreamingControlViewModel {
     var isSignalingConnected: Bool = false
     /// Receiver(Vision Pro) 준비 상태
     var isReceiverReady: Bool = false
+    /// Bonjour 탐색 상태
+    var isDiscoveringServer: Bool = false
+    /// 발견된 서버 URL
+    var discoveredServerURL: URL?
 
     // MARK: - State: Inspector Settings
 
@@ -188,17 +196,75 @@ public final class StreamingControlViewModel {
 
     init() {
         loadAvailableDevices()
-        connectToSignalingServer()
+        startBonjourDiscovery()
+    }
+
+    // MARK: - Bonjour Discovery
+
+    /// Bonjour를 사용해 시그널링 서버 자동 탐색 시작
+    private func startBonjourDiscovery() {
+        logger.info("🔍 Starting Bonjour discovery for signaling server...")
+        isDiscoveringServer = true
+
+        // Bonjour 상태 변화 감시
+        Task { @MainActor in
+            for await state in bonjourDiscovery.$discoveryState.values {
+                await handleBonjourStateChange(state)
+            }
+        }
+
+        bonjourDiscovery.startDiscovery()
+    }
+
+    /// Bonjour 탐색 상태 변화 처리
+    private func handleBonjourStateChange(_ state: BonjourDiscoveryState) async {
+        switch state {
+        case .idle:
+            logger.info("Bonjour: idle")
+
+        case .discovering:
+            logger.info("Bonjour: discovering...")
+            isDiscoveringServer = true
+
+        case .resolved(let host, let port):
+            logger.info("✅ Bonjour: Server found at \(host):\(port)")
+            isDiscoveringServer = false
+
+            let serverURL = URL(string: "ws://\(host):\(port)")!
+            discoveredServerURL = serverURL
+            connectToSignalingServer(url: serverURL)
+
+        case .fallbackUsingLastEndpoint(let host, let port):
+            logger.info("⚠️ Bonjour: Using fallback endpoint \(host):\(port)")
+            isDiscoveringServer = false
+
+            let serverURL = URL(string: "ws://\(host):\(port)")!
+            discoveredServerURL = serverURL
+            connectToSignalingServer(url: serverURL)
+
+        case .failed(let error):
+            logger.error("❌ Bonjour discovery failed: \(error)")
+            isDiscoveringServer = false
+            errorMessage = "서버를 찾을 수 없습니다: \(error)"
+
+            // Fallback to localhost
+            logger.info("🔄 Falling back to localhost...")
+            let fallbackURL = URL(string: "ws://127.0.0.1:8080")!
+            discoveredServerURL = fallbackURL
+            connectToSignalingServer(url: fallbackURL)
+        }
     }
 
     // MARK: - Signaling Server Connection
 
-    /// 시그널링 서버에 연결 (앱 시작 시 자동 호출)
-    private func connectToSignalingServer() {
-        let serverURL = URL(string: "ws://127.0.0.1:8080")!
-        logger.info("Connecting to signaling server: \(serverURL.absoluteString)")
+    /// 시그널링 서버에 연결
+    private func connectToSignalingServer(url: URL) {
+        logger.info("Connecting to signaling server: \(url.absoluteString)")
 
-        signalingClient = SignalingClient(serverURL: serverURL)
+        // 기존 연결 해제
+        signalingClient?.disconnect()
+
+        signalingClient = SignalingClient(serverURL: url)
         signalingClient?.delegate = self
 
         do {
@@ -211,16 +277,18 @@ public final class StreamingControlViewModel {
 
     /// 시그널링 서버 연결 해제
     private func disconnectFromSignalingServer() {
+        bonjourDiscovery.stopDiscovery()
         signalingClient?.disconnect()
         signalingClient = nil
         isSignalingConnected = false
         isReceiverReady = false
+        discoveredServerURL = nil
     }
 
-    /// 시그널링 서버 재연결
+    /// 시그널링 서버 재연결 (Bonjour 탐색부터 다시 시작)
     func reconnectToSignalingServer() {
         disconnectFromSignalingServer()
-        connectToSignalingServer()
+        startBonjourDiscovery()
     }
 
     // MARK: - Public Methods: Device Management
@@ -647,11 +715,16 @@ extension StreamingControlViewModel: SignalingDelegate {
 
     nonisolated public func signalingClientDidReceiveReceiverReady(_ client: SignalingClient) {
         Task { @MainActor in
-            self.logger.info("🎉 Receiver (Vision Pro) is ready! Auto-starting streaming...")
+            self.logger.info("🎉 Receiver (Vision Pro) is ready!")
             self.isReceiverReady = true
 
-            // 자동으로 스트리밍 시작
-            if !self.isStreaming {
+            if self.isStreaming {
+                // 이미 스트리밍 중이면 새로운 Offer 생성 (renegotiate)
+                self.logger.info("🔄 Already streaming, creating new offer for receiver...")
+                self.transport?.createOffer()
+            } else {
+                // 스트리밍 중이 아니면 자동으로 시작
+                self.logger.info("▶️ Auto-starting streaming...")
                 do {
                     try await self.startStreaming()
                 } catch {

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlViewModel.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlViewModel.swift
@@ -27,9 +27,15 @@ fileprivate struct SendablePixelBuffer: @unchecked Sendable {
 // MARK: - StreamingControlViewModel
 
 /// Streaming control view model
+/// Singleton to persist across tab switches
 @MainActor
 @Observable
 public final class StreamingControlViewModel {
+
+    // MARK: - Singleton
+
+    /// Shared instance to persist across tab switches
+    public static let shared = StreamingControlViewModel()
 
     // MARK: - Dependencies
 
@@ -39,14 +45,14 @@ public final class StreamingControlViewModel {
     private var composer: CI_SBSComposer?
     private var transport: WebRTCManager?
 
+    // Embedded signaling server (replaces external node server.js)
+    private let signalingServer = EmbeddedSignalingServer()
+
     // Signaling client for auto-start (always connected, waiting for receiver)
     private var signalingClient: SignalingClient?
 
-    // Bonjour service discovery for auto-detecting signaling server
-    private let bonjourDiscovery = BonjourServiceDiscovery()
-
-    // Preview display layer (set from view)
-    public var previewLayer: AVSampleBufferDisplayLayer?
+    // Preview display layer - owned by ViewModel to persist across tab switches
+    public let previewLayer = AVSampleBufferDisplayLayer()
 
     private let logger = Logger(subsystem: "com.television.hippo", category: "StreamingControl")
 
@@ -161,14 +167,12 @@ public final class StreamingControlViewModel {
 
     // MARK: - State: Signaling Connection
 
+    /// 내장 시그널링 서버 상태
+    var signalingServerState: SignalingServerState = .idle
     /// 시그널링 서버 연결 상태
     var isSignalingConnected: Bool = false
     /// Receiver(Vision Pro) 준비 상태
     var isReceiverReady: Bool = false
-    /// Bonjour 탐색 상태
-    var isDiscoveringServer: Bool = false
-    /// 발견된 서버 URL
-    var discoveredServerURL: URL?
 
     // MARK: - State: Inspector Settings
 
@@ -194,64 +198,52 @@ public final class StreamingControlViewModel {
 
     // MARK: - Initialization
 
-    init() {
+    /// Private init for singleton
+    private init() {
         loadAvailableDevices()
-        startBonjourDiscovery()
+        startEmbeddedServer()
     }
 
-    // MARK: - Bonjour Discovery
+    // MARK: - Embedded Signaling Server
 
-    /// Bonjour를 사용해 시그널링 서버 자동 탐색 시작
-    private func startBonjourDiscovery() {
-        logger.info("🔍 Starting Bonjour discovery for signaling server...")
-        isDiscoveringServer = true
+    /// 내장 시그널링 서버 시작
+    private func startEmbeddedServer() {
+        logger.info("🚀 Starting embedded signaling server...")
 
-        // Bonjour 상태 변화 감시
+        // 서버 상태 변화 감시
         Task { @MainActor in
-            for await state in bonjourDiscovery.$discoveryState.values {
-                await handleBonjourStateChange(state)
+            for await state in signalingServer.$state.values {
+                await handleServerStateChange(state)
             }
         }
 
-        bonjourDiscovery.startDiscovery()
+        signalingServer.start()
     }
 
-    /// Bonjour 탐색 상태 변화 처리
-    private func handleBonjourStateChange(_ state: BonjourDiscoveryState) async {
+    /// 서버 상태 변화 처리
+    private func handleServerStateChange(_ state: SignalingServerState) async {
+        signalingServerState = state
+
         switch state {
         case .idle:
-            logger.info("Bonjour: idle")
+            logger.info("Server: idle")
 
-        case .discovering:
-            logger.info("Bonjour: discovering...")
-            isDiscoveringServer = true
+        case .starting:
+            logger.info("Server: starting...")
 
-        case .resolved(let host, let port):
-            logger.info("✅ Bonjour: Server found at \(host):\(port)")
-            isDiscoveringServer = false
-
-            let serverURL = URL(string: "ws://\(host):\(port)")!
-            discoveredServerURL = serverURL
-            connectToSignalingServer(url: serverURL)
-
-        case .fallbackUsingLastEndpoint(let host, let port):
-            logger.info("⚠️ Bonjour: Using fallback endpoint \(host):\(port)")
-            isDiscoveringServer = false
-
-            let serverURL = URL(string: "ws://\(host):\(port)")!
-            discoveredServerURL = serverURL
+        case .running(let port):
+            logger.info("✅ Server running on port \(port)")
+            // 서버가 시작되면 클라이언트로 연결
+            let serverURL = URL(string: "ws://127.0.0.1:\(port)")!
             connectToSignalingServer(url: serverURL)
 
         case .failed(let error):
-            logger.error("❌ Bonjour discovery failed: \(error)")
-            isDiscoveringServer = false
-            errorMessage = "서버를 찾을 수 없습니다: \(error)"
+            logger.error("❌ Server failed: \(error)")
+            errorMessage = "시그널링 서버 시작 실패: \(error)"
 
-            // Fallback to localhost
-            logger.info("🔄 Falling back to localhost...")
-            let fallbackURL = URL(string: "ws://127.0.0.1:8080")!
-            discoveredServerURL = fallbackURL
-            connectToSignalingServer(url: fallbackURL)
+        case .stopped:
+            logger.info("Server stopped")
+            isSignalingConnected = false
         }
     }
 
@@ -277,18 +269,22 @@ public final class StreamingControlViewModel {
 
     /// 시그널링 서버 연결 해제
     private func disconnectFromSignalingServer() {
-        bonjourDiscovery.stopDiscovery()
         signalingClient?.disconnect()
         signalingClient = nil
         isSignalingConnected = false
         isReceiverReady = false
-        discoveredServerURL = nil
     }
 
-    /// 시그널링 서버 재연결 (Bonjour 탐색부터 다시 시작)
-    func reconnectToSignalingServer() {
+    /// 시그널링 서버 재시작
+    func restartSignalingServer() {
         disconnectFromSignalingServer()
-        startBonjourDiscovery()
+        signalingServer.stop()
+
+        // 잠시 대기 후 재시작
+        Task {
+            try? await Task.sleep(for: .milliseconds(500))
+            signalingServer.start()
+        }
     }
 
     // MARK: - Public Methods: Device Management
@@ -381,12 +377,10 @@ public final class StreamingControlViewModel {
         transport = nil
 
         // Clear preview
-        if let layer = previewLayer {
-            if #available(macOS 15.0, *) {
-                layer.sampleBufferRenderer.flush()
-            } else {
-                layer.flush()
-            }
+        if #available(macOS 15.0, *) {
+            previewLayer.sampleBufferRenderer.flush()
+        } else {
+            previewLayer.flush()
         }
 
         isStreaming = false
@@ -572,7 +566,7 @@ public final class StreamingControlViewModel {
     /// OPTIMIZED: Preview rendering with autoreleasepool and reduced overhead
     @MainActor
     private func updatePreview(_ pixelBuffer: CVPixelBuffer, pts: CMTime) async {
-        guard let layer = previewLayer else { return }
+        let layer = previewLayer
 
         // OPTIMIZED: Use autoreleasepool to prevent memory accumulation
         autoreleasepool {

--- a/Hippo/Features/Mac/UI/StreamingControl/StreamingControlViewModel.swift
+++ b/Hippo/Features/Mac/UI/StreamingControl/StreamingControlViewModel.swift
@@ -38,6 +38,9 @@ public final class StreamingControlViewModel {
     private var composer: CI_SBSComposer?
     private var transport: WebRTCManager?
 
+    // Signaling client for auto-start (always connected, waiting for receiver)
+    private var signalingClient: SignalingClient?
+
     // Preview display layer (set from view)
     public var previewLayer: AVSampleBufferDisplayLayer?
 
@@ -152,6 +155,13 @@ public final class StreamingControlViewModel {
     var isStreaming: Bool = false
     var errorMessage: String?
 
+    // MARK: - State: Signaling Connection
+
+    /// 시그널링 서버 연결 상태
+    var isSignalingConnected: Bool = false
+    /// Receiver(Vision Pro) 준비 상태
+    var isReceiverReady: Bool = false
+
     // MARK: - State: Inspector Settings
 
     var normalizationPolicy: NormalizePolicy = .cropToMatchAspect
@@ -178,6 +188,39 @@ public final class StreamingControlViewModel {
 
     init() {
         loadAvailableDevices()
+        connectToSignalingServer()
+    }
+
+    // MARK: - Signaling Server Connection
+
+    /// 시그널링 서버에 연결 (앱 시작 시 자동 호출)
+    private func connectToSignalingServer() {
+        let serverURL = URL(string: "ws://127.0.0.1:8080")!
+        logger.info("Connecting to signaling server: \(serverURL.absoluteString)")
+
+        signalingClient = SignalingClient(serverURL: serverURL)
+        signalingClient?.delegate = self
+
+        do {
+            try signalingClient?.connect(as: "sender")
+        } catch {
+            logger.error("Failed to connect to signaling server: \(error.localizedDescription)")
+            errorMessage = "시그널링 서버 연결 실패"
+        }
+    }
+
+    /// 시그널링 서버 연결 해제
+    private func disconnectFromSignalingServer() {
+        signalingClient?.disconnect()
+        signalingClient = nil
+        isSignalingConnected = false
+        isReceiverReady = false
+    }
+
+    /// 시그널링 서버 재연결
+    func reconnectToSignalingServer() {
+        disconnectFromSignalingServer()
+        connectToSignalingServer()
     }
 
     // MARK: - Public Methods: Device Management
@@ -279,6 +322,7 @@ public final class StreamingControlViewModel {
         }
 
         isStreaming = false
+        isReceiverReady = false  // Reset receiver ready state
 
         // 통계 초기화
         resetStatistics()
@@ -340,8 +384,11 @@ public final class StreamingControlViewModel {
         try rightSession.start(settings: captureSettings)
         self.rightCapture = rightSession
 
-        // Start WebRTC transport
-        try webrtc.start()
+        // Start WebRTC transport with external signaling client
+        guard let signalingClient = signalingClient else {
+            throw StreamingError.networkError("시그널링 서버에 연결되지 않았습니다")
+        }
+        try webrtc.start(with: signalingClient)
 
         logger.info("Dual camera capture started")
     }
@@ -377,8 +424,11 @@ public final class StreamingControlViewModel {
         try leftSession.start()  // No settings = use native resolution
         self.leftCapture = leftSession
 
-        // Start WebRTC transport
-        try webrtc.start()
+        // Start WebRTC transport with external signaling client
+        guard let signalingClient = signalingClient else {
+            throw StreamingError.networkError("시그널링 서버에 연결되지 않았습니다")
+        }
+        try webrtc.start(with: signalingClient)
 
         logger.info("Mono capture started with native resolution")
     }
@@ -567,6 +617,70 @@ extension StreamingControlViewModel: CaptureOutputDelegate {
             self.logger.error("Capture error [\(source.rawValue)]: \(error.localizedDescription)")
             self.errorMessage = error.localizedDescription
         }
+    }
+}
+
+// MARK: - SignalingDelegate
+
+extension StreamingControlViewModel: SignalingDelegate {
+    nonisolated public func signalingClient(_ client: SignalingClient, didChangeState state: SignalingState) {
+        Task { @MainActor in
+            switch state {
+            case .connected:
+                self.logger.info("✅ Signaling server connected")
+                self.isSignalingConnected = true
+                self.errorMessage = nil
+            case .disconnected:
+                self.logger.info("Signaling server disconnected")
+                self.isSignalingConnected = false
+                self.isReceiverReady = false
+            case .connecting:
+                self.logger.info("Connecting to signaling server...")
+            case .failed:
+                self.logger.error("❌ Signaling server connection failed")
+                self.isSignalingConnected = false
+                self.isReceiverReady = false
+                self.errorMessage = "시그널링 서버 연결 실패"
+            }
+        }
+    }
+
+    nonisolated public func signalingClientDidReceiveReceiverReady(_ client: SignalingClient) {
+        Task { @MainActor in
+            self.logger.info("🎉 Receiver (Vision Pro) is ready! Auto-starting streaming...")
+            self.isReceiverReady = true
+
+            // 자동으로 스트리밍 시작
+            if !self.isStreaming {
+                do {
+                    try await self.startStreaming()
+                } catch {
+                    self.logger.error("Failed to auto-start streaming: \(error.localizedDescription)")
+                    self.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    // WebRTC signaling messages - forward to WebRTCManager
+    nonisolated public func signalingClient(_ client: SignalingClient, didReceiveOffer sdp: String) {
+        // Sender doesn't receive offers
+    }
+
+    nonisolated public func signalingClient(_ client: SignalingClient, didReceiveAnswer sdp: String) {
+        Task { @MainActor in
+            self.transport?.handleAnswer(sdp: sdp)
+        }
+    }
+
+    nonisolated public func signalingClient(_ client: SignalingClient, didReceiveCandidate candidate: String, sdpMid: String?, sdpMLineIndex: Int32) {
+        Task { @MainActor in
+            self.transport?.handleRemoteCandidate(candidate: candidate, sdpMid: sdpMid, sdpMLineIndex: sdpMLineIndex)
+        }
+    }
+
+    nonisolated public func signalingClientDidReceiveRenegotiate(_ client: SignalingClient) {
+        // Handle renegotiation if needed
     }
 }
 

--- a/Hippo/Features/Vision/Endoscope/Streaming/Receiver/WebRTCReceiver.swift
+++ b/Hippo/Features/Vision/Endoscope/Streaming/Receiver/WebRTCReceiver.swift
@@ -682,17 +682,17 @@ extension WebRTCReceiver: LKRTCVideoRenderer {
 }
 
 extension WebRTCReceiver: SignalingDelegate {
-    nonisolated func signalingClient(_ client: SignalingClient, didReceiveOffer sdp: String) {
+    nonisolated public func signalingClient(_ client: SignalingClient, didReceiveOffer sdp: String) {
         handleOffer(sdp)
     }
 
-    nonisolated func signalingClient(_ client: SignalingClient, didReceiveAnswer sdp: String) {
+    nonisolated public func signalingClient(_ client: SignalingClient, didReceiveAnswer sdp: String) {
         Task { @MainActor in
             self.logger.warning("Received unexpected answer (Vision Pro is receiver)")
         }
     }
 
-    nonisolated func signalingClient(_ client: SignalingClient, didReceiveCandidate candidate: String, sdpMid: String?, sdpMLineIndex: Int32) {
+    nonisolated public func signalingClient(_ client: SignalingClient, didReceiveCandidate candidate: String, sdpMid: String?, sdpMLineIndex: Int32) {
         Task { @MainActor [weak self] in
             guard let self = self else { return }
 
@@ -715,7 +715,7 @@ extension WebRTCReceiver: SignalingDelegate {
         }
     }
 
-    nonisolated func signalingClient(_ client: SignalingClient, didChangeState state: SignalingState) {
+    nonisolated public func signalingClient(_ client: SignalingClient, didChangeState state: SignalingState) {
         Task { @MainActor in
             self.logger.info("Signaling state: \(String(describing: state))")
         }

--- a/Hippo/Shared/Core/ITransport.swift
+++ b/Hippo/Shared/Core/ITransport.swift
@@ -15,9 +15,10 @@ import CoreMedia
 /// Abstract transport interface for sending video frames
 /// Implementation: WebRTC with H.264 encoding
 public protocol ITransport: AnyObject {
-    /// Start the transport session
-    /// Initializes peer connection, performs signaling
-    func start() throws
+    /// Start the transport session with external signaling client
+    /// Initializes peer connection, creates offer
+    /// - Parameter signalingClient: External SignalingClient managed by caller
+    func start(with signalingClient: SignalingClient) throws
 
     /// Stop the transport session
     /// Closes peer connection, releases resources

--- a/Hippo/Shared/Core/SignalingClient.swift
+++ b/Hippo/Shared/Core/SignalingClient.swift
@@ -65,7 +65,7 @@ enum SignalingMessage: Codable {
 
 // MARK: - Signaling Delegate
 
-protocol SignalingDelegate: AnyObject {
+public protocol SignalingDelegate: AnyObject {
     func signalingClient(_ client: SignalingClient, didReceiveOffer sdp: String)
     func signalingClient(_ client: SignalingClient, didReceiveAnswer sdp: String)
     func signalingClient(_ client: SignalingClient, didReceiveCandidate candidate: String, sdpMid: String?, sdpMLineIndex: Int32)
@@ -74,14 +74,14 @@ protocol SignalingDelegate: AnyObject {
     func signalingClient(_ client: SignalingClient, didChangeState state: SignalingState)
 }
 
-extension SignalingDelegate {
+public extension SignalingDelegate {
     func signalingClientDidReceiveRenegotiate(_ client: SignalingClient) {}
     func signalingClientDidReceiveReceiverReady(_ client: SignalingClient) {}
 }
 
 // MARK: - Signaling State
 
-enum SignalingState {
+public enum SignalingState {
     case disconnected
     case connecting
     case connected
@@ -92,11 +92,11 @@ enum SignalingState {
 
 /// WebSocket-based signaling client
 /// P0.3 Enhancement: Automatic reconnection with exponential backoff
-final class SignalingClient {
+public final class SignalingClient {
 
     // MARK: Properties
 
-    weak var delegate: SignalingDelegate?
+    public weak var delegate: SignalingDelegate?
 
     private let serverURL: URL
     private var webSocketTask: URLSessionWebSocketTask?
@@ -127,7 +127,7 @@ final class SignalingClient {
 
     // MARK: Initialization
 
-    init(serverURL: URL, reconnectionPolicy: ReconnectionPolicy = .standard) {
+    public init(serverURL: URL, reconnectionPolicy: ReconnectionPolicy = .standard) {
         self.serverURL = serverURL
         self.reconnectionPolicy = reconnectionPolicy
 
@@ -145,7 +145,7 @@ final class SignalingClient {
 
     // MARK: - Public Methods
 
-    func connect(as role: String) throws {
+    public func connect(as role: String) throws {
         guard state == .disconnected else {
             logger.warning("⚠️ Already connected or connecting")
             return
@@ -202,7 +202,7 @@ final class SignalingClient {
         }
     }
 
-    func disconnect() {
+    public func disconnect() {
         cancelReconnection()  // P0.3: Cancel any pending reconnection
         stopPingTimer()  // Stop keepalive pings
         // Immediately cancel WebSocket without waiting for server response
@@ -214,17 +214,17 @@ final class SignalingClient {
 
     // MARK: - Sending Messages
 
-    func send(offer sdp: String, to targetId: String = "receiver") {
+    public func send(offer sdp: String, to targetId: String = "receiver") {
         let message = SignalingMessage.offer(sdp: sdp)
         sendMessage(message, to: targetId)
     }
 
-    func send(answer sdp: String, to targetId: String = "sender") {
+    public func send(answer sdp: String, to targetId: String = "sender") {
         let message = SignalingMessage.answer(sdp: sdp)
         sendMessage(message, to: targetId)
     }
 
-    func send(iceCandidate candidate: LKRTCIceCandidate, to targetId: String? = nil) {
+    public func send(iceCandidate candidate: LKRTCIceCandidate, to targetId: String? = nil) {
         // Auto-detect targetId based on role
         let target = targetId ?? (currentRole == "sender" ? "receiver" : "sender")
         let message = SignalingMessage.iceCandidate(


### PR DESCRIPTION
## 📕 Issue Number

Close #201 


## 📙 작업 내역

> 구현 내용 및 작업 했던 내역

 - 내장 WebSocket 시그널링 서버 구현
    - EmbeddedSignalingServer: node server.js 없이 앱 내에서 시그널링 서버 실행
    - SignalingServerTypes: 서버 상태 enum 및 Configuration 정의
    - SignalingConnection: 연결된 클라이언트 모델
    - Bonjour(_ws._tcp) 서비스 자동 퍼블리싱 지원
    - 하트비트 기반 연결 상태 모니터링
  - StreamingControlViewModel 싱글톤 패턴 적용
    - 탭 전환 시 ViewModel 재생성 방지
    - previewLayer를 ViewModel이 직접 소유하도록 변경
    - 서버 중복 시작 방지 로직 추가
  - RootView 탭 전환 방식 개선
    - switch 기반 View 교체 → opacity 기반 show/hide 방식으로 변경
    - StreamingControlView가 탭 전환 시 파괴되지 않고 유지됨
  - WebRTC 재연결 안정성 개선
    - SSL/tracer 초기화를 앱 생명주기 동안 1회만 수행
    - stop 시 cleanup 호출 제거로 재연결 crash 방지
    - createOffer() public으로 변경하여 renegotiation 지원
  - Bonjour 서비스 자동 탐색 기능 추가
    - Bonjour를 통한 시그널링 서버 자동 탐색
    - Bonjour 실패 시 localhost fallback 처리
  - SignalingClient 구조 리팩토링
    - WebRTCManager에서 외부 주입 방식으로 변경
    - StreamingControlViewModel에서 SignalingClient 수명 관리
    - Receiver Ready 시 자동 스트리밍 시작 기능 추가


## 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부

- 스크린 샷


## 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


## 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

  - 더 이상 별도의 node server.js 실행 없이 Mac 앱만으로 시그널링 서버가 동작합니다
<br><br>
